### PR TITLE
Fix category deserialization, other minor changes

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/PodcastError.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/PodcastError.kt
@@ -4,4 +4,6 @@ sealed interface PodcastError {
     data class NoInternet(val throwable: Throwable) : PodcastError
 
     data class Unknown(val throwable: Throwable?) : PodcastError
+
+    data class BadRequest(val throwable: Throwable? = null) : PodcastError
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/network/api/PodcastsApiImpl.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/network/api/PodcastsApiImpl.kt
@@ -39,7 +39,7 @@ internal class PodcastsApiImpl(
                         append("q", request.term)
                         append("max", MAX_COUNT.toString())
                         append("fulltext", "true")
-                        append("similar", "true")
+                        append("similar", request.findSimilar.toString())
                         append("clean", "true")
                     }
                 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/network/model/SearchPodcastsRequest.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/network/model/SearchPodcastsRequest.kt
@@ -1,3 +1,3 @@
 package com.ramitsuri.podcasts.network.model
 
-data class SearchPodcastsRequest(val term: String)
+data class SearchPodcastsRequest(val term: String, val findSimilar: Boolean = true)

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/network/serialization/CategoriesDeserializer.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/network/serialization/CategoriesDeserializer.kt
@@ -4,6 +4,7 @@ import com.ramitsuri.podcasts.network.model.CategoryDto
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.JsonTransformingSerializer
@@ -12,6 +13,9 @@ import kotlinx.serialization.json.buildJsonObject
 internal object CategoriesDeserializer :
     JsonTransformingSerializer<List<CategoryDto>>(ListSerializer(CategoryDto.serializer())) {
     override fun transformDeserialize(element: JsonElement): JsonArray {
+        if (element is JsonNull) {
+            return JsonArray(listOf())
+        }
         return JsonArray(
             (element as JsonObject).entries.map { (k, v) ->
                 buildJsonObject {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/network/utils/NetworkUtils.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/network/utils/NetworkUtils.kt
@@ -32,6 +32,10 @@ internal suspend inline fun <reified T> apiRequest(
                 PodcastResult.Success(response.body())
             }
 
+            response?.status == HttpStatusCode.BadRequest -> {
+                PodcastResult.Failure(PodcastError.BadRequest())
+            }
+
             exception is IOException -> {
                 PodcastResult.Failure(PodcastError.NoInternet(exception))
             }


### PR DESCRIPTION
Started solving for when import subscription isn't found and found out
that categories in the get podcast by url or search API can be null.
So accounting for that.

When podcast by url isn't found, then it returns a bad request, so
capturing that error in case want to surface that to UI
