### PR TITLE
Fix podcast has new episodes issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ xcuserdata
 !/.idea/inspectionProfiles/*
 
 secret.properties
+*.aab

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/interfaces/EpisodesDao.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/interfaces/EpisodesDao.kt
@@ -12,7 +12,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
 
 internal interface EpisodesDao {
-    suspend fun insert(episodes: List<Episode>)
+    /**
+     * Returns count of how many episodes are inserted.
+     * If additional data is not inserted but episode data is, that counts as not inserted
+     */
+    suspend fun insert(episodes: List<Episode>): Int
 
     fun getEpisodesForPodcastsFlow(podcastIds: List<Long>): Flow<List<GetEpisodesForPodcasts>>
 

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
@@ -37,8 +37,8 @@ class EpisodesRepository internal constructor(
             )
         return when (val result = episodesApi.getByPodcastId(request)) {
             is PodcastResult.Success -> {
-                episodesDao.insert(result.data.items.map { Episode(it) })
-                PodcastResult.Success(RefreshedEpisodes(count = result.data.items.count()))
+                val insertCount = episodesDao.insert(result.data.items.map { Episode(it) })
+                PodcastResult.Success(RefreshedEpisodes(count = insertCount))
             }
 
             is PodcastResult.Failure -> {

--- a/shared/src/commonMain/sqldelight/com/ramitsuri/podcasts/EpisodeAdditionalInfoEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/ramitsuri/podcasts/EpisodeAdditionalInfoEntity.sq
@@ -21,6 +21,11 @@ INSERT OR IGNORE INTO
 EpisodeAdditionalInfoEntity(id, playProgress, downloadStatus, downloadProgress, downloadBlocked, downloadedAt, queuePosition, completedAt, isFavorite)
 VALUES ?;
 
+hasId:
+SELECT COUNT(*)
+FROM EpisodeAdditionalInfoEntity
+WHERE id = :id;
+
 updatePlayProgress:
 UPDATE EpisodeAdditionalInfoEntity
 SET playProgress = :playProgress


### PR DESCRIPTION
When I added this change, podcast has new episodes boolean was always
getting written to true because we would always get a result from the
API as we get episodes since (last episode's fetch time - 1 hour).

So that last episode will always be fetched. This means that it was
resetting the has new episodes to true always.

Fix was to rely on the rows that get written to the db for that value.

Tried things where Sqlite allows getting the row number for row that
gets inserted and it's 0 if not inserted but that was yielding wrong
results for episode additional data table. Had to add a new query to
see if episode is already available in the additional data table and
then skip adding it, plus return the insert result as false even though
we still insert the episode data in the table in that case.

That is because episode data could change, but additional data is our
data and only we would change it via separate methods.
