### PR TITLE
Fix work manager initialization

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.koin.android)
     implementation(libs.koin.android.compose)
+    implementation(libs.koin.workmanager)
     implementation(libs.kotlin.datetime)
     implementation(libs.media3.common)
     implementation(libs.media3.exoplayer)

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -40,5 +41,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </service>
+
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
     </application>
 </manifest> 

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/utils/EpisodeFetchWorker.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/utils/EpisodeFetchWorker.kt
@@ -10,19 +10,21 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.ramitsuri.podcasts.android.BuildConfig
 import com.ramitsuri.podcasts.android.R
 import com.ramitsuri.podcasts.utils.EpisodeFetcher
+import com.ramitsuri.podcasts.utils.LogHelper
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import java.util.concurrent.TimeUnit
 
 class EpisodeFetchWorker(
+    private val episodeFetcher: EpisodeFetcher,
     context: Context,
     workerParams: WorkerParameters,
 ) : CoroutineWorker(context, workerParams) {
-    private val episodeFetcher by inject<EpisodeFetcher>()
 
     override suspend fun doWork(): Result {
+        LogHelper.d(TAG, "Starting work")
         episodeFetcher.fetchPodcastsIfNecessary(forced = true)
         return Result.success()
     }
@@ -43,11 +45,16 @@ class EpisodeFetchWorker(
     }
 
     companion object : KoinComponent {
+        private const val TAG = "EpisodeFetchWorker"
         private const val WORK_NAME_PERIODIC = "EpisodeFetchWorker"
         private const val REPEAT_HOURS: Long = 12
         private const val NOTIFICATION_ID = NotificationId.EPISODE_FETCH_WORKER
 
         fun enqueuePeriodic(context: Context) {
+            if (BuildConfig.DEBUG) {
+                LogHelper.d(TAG, "Skipping in debug build")
+                return
+            }
             val builder =
                 PeriodicWorkRequest
                     .Builder(EpisodeFetchWorker::class.java, REPEAT_HOURS, TimeUnit.HOURS)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/utils/EpisodeFetchWorker.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/utils/EpisodeFetchWorker.kt
@@ -22,7 +22,6 @@ class EpisodeFetchWorker(
     context: Context,
     workerParams: WorkerParameters,
 ) : CoroutineWorker(context, workerParams) {
-
     override suspend fun doWork(): Result {
         LogHelper.d(TAG, "Starting work")
         episodeFetcher.fetchPodcastsIfNecessary(forced = true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ html-converter = { group = "be.digitalia.compose.htmlconverter", name = "htmlcon
 koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-android-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
+koin-workmanager = { group = "io.insert-koin", name = "koin-androidx-workmanager", version.ref = "koin" }
 koin-test = { group = "io.insert-koin", name = "koin-test", version.ref = "koin" }
 
 ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/Koin.kt
@@ -42,11 +42,11 @@ import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
-fun initKoin(appModule: Module): KoinApplication {
+fun initKoin(appModule: KoinApplication.() -> Module): KoinApplication {
     val koinApplication =
         startKoin {
             modules(
-                appModule,
+                appModule(),
                 platformModule,
                 coreModule,
             )
@@ -168,6 +168,7 @@ private val coreModule =
                 clock = get<Clock>(),
                 foregroundStateObserver = get<ForegroundStateObserver>(),
                 longLivingScope = get<CoroutineScope>(),
+                isDebug = get<AppInfo>().isDebug,
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/EpisodeFetcher.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/EpisodeFetcher.kt
@@ -16,10 +16,15 @@ class EpisodeFetcher(
     private val clock: Clock,
     private val foregroundStateObserver: ForegroundStateObserver,
     private val longLivingScope: CoroutineScope,
+    private val isDebug: Boolean,
 ) {
     private val refreshPodcastsMutex = Mutex()
 
     fun startForegroundStateBasedFetcher() {
+        if (isDebug) {
+            LogHelper.d(TAG, "Skipping in debug build")
+            return
+        }
         longLivingScope.launch {
             foregroundStateObserver.state.collect { foregroundState ->
                 if (!foregroundState.isInForeground) {


### PR DESCRIPTION
Noticed in debug builds at least, `EpisodeFetchWorker` was having
trouble getting initialized because `ProcessLifecycleOwner` needed
by `ForegroundStateObserver`, requires the callback to be set on
main thread. But the way koin initializes dependencies, is lazy
and so initialization can happen when the dependency is actually
needed.

Tried to use `= get()` in the worker instead of previous `by inject()`
which instantiates the object right away and not lazily but that was
throwing the same error about the callback needing to be in main
thread.

The fix was to use our own work manager factory provided via Koin
and then also let the `EpisodeFetcher` get initialized in
`MainApplication` in debug builds as well. Then the individual classes
skip doing work if we're on a debug build.
