### PR TITLE
Fix episode not getting marked as completed

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PodcastMediaSessionService.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PodcastMediaSessionService.kt
@@ -429,6 +429,10 @@ class PodcastMediaSessionService : MediaSessionService(), KoinComponent {
         attemptingToPlayNextMedia = true
         launchSuspend {
             delay(500)
+            val currentlyPlayingEpisode = currentlyPlayingEpisode.value
+            if (currentlyPlayingEpisode != null) {
+                episodesRepository.markPlayed(currentlyPlayingEpisode.id)
+            }
             val autoPlayNextInQueue = settings.autoPlayNextInQueue().first()
             if (!autoPlayNextInQueue) {
                 LogHelper.d(TAG, "Auto play next in queue is false")
@@ -443,10 +447,6 @@ class PodcastMediaSessionService : MediaSessionService(), KoinComponent {
                 return@launchSuspend
             }
             val queue = episodesRepository.getQueue()
-            val currentlyPlayingEpisode = currentlyPlayingEpisode.value
-            if (currentlyPlayingEpisode != null) {
-                episodesRepository.markPlayed(currentlyPlayingEpisode.id)
-            }
             val currentEpisodeIndex = queue.indexOfFirst { it.id == currentlyPlayingEpisode?.id }
             if (currentEpisodeIndex == -1) {
                 LogHelper.v(TAG, "current episode not found")


### PR DESCRIPTION
When auto play is not on, the currently playing episode was not getting
marked as completed, as in the function that plays the next episode,
I was exiting early if auto play was off.

This moves the mark current episode as completed to be the first line
which is always called irrespective of if auto play next is on or not.
