### PR TITLE
Fix background download of episode file

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/utils/EpisodeFetchWorker.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/utils/EpisodeFetchWorker.kt
@@ -24,7 +24,9 @@ class EpisodeFetchWorker(
 ) : CoroutineWorker(context, workerParams) {
     override suspend fun doWork(): Result {
         LogHelper.d(TAG, "Starting work")
-        episodeFetcher.fetchPodcastsIfNecessary(forced = true)
+        // Cannot auto download episodes from a worker because of restriction on starting foreground service (which
+        // episode downloader starts) from background (which a worker is)
+        episodeFetcher.fetchPodcastsIfNecessary(forced = true, systemAllowsAutoDownload = false)
         return Result.success()
     }
 

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/utils/EpisodeFetchWorker.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/utils/EpisodeFetchWorker.kt
@@ -26,7 +26,7 @@ class EpisodeFetchWorker(
         LogHelper.d(TAG, "Starting work")
         // Cannot auto download episodes from a worker because of restriction on starting foreground service (which
         // episode downloader starts) from background (which a worker is)
-        episodeFetcher.fetchPodcastsIfNecessary(forced = true, systemAllowsAutoDownload = false)
+        episodeFetcher.fetchPodcastsIfNecessary(forced = true, episodeDownloadAllowed = false)
         return Result.success()
     }
 

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/PodcastRefreshResult.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/PodcastRefreshResult.kt
@@ -1,6 +1,0 @@
-package com.ramitsuri.podcasts.model
-
-data class PodcastRefreshResult(
-    val autoDownloadableEpisodes: List<Episode>,
-    val autoAddToQueueEpisodes: List<Episode>,
-)

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/PodcastsAndEpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/PodcastsAndEpisodesRepository.kt
@@ -44,7 +44,7 @@ class PodcastsAndEpisodesRepository internal constructor(
 
     suspend fun refreshPodcasts(
         fetchFromNetwork: Boolean,
-        systemAllowsAutoDownload: Boolean = false,
+        episodeDownloadAllowed: Boolean = false,
     ): PodcastResult<Unit> {
         return withContext(ioDispatcher) {
             val failures = mutableListOf<PodcastResult.Failure>()
@@ -64,7 +64,7 @@ class PodcastsAndEpisodesRepository internal constructor(
                     }
                 }.joinAll()
             }
-            if (systemAllowsAutoDownload) {
+            if (episodeDownloadAllowed) {
                 episodesRepository
                     .getNeedDownloadEpisodes()
                     .forEach { episode ->

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/EpisodeFetcher.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/EpisodeFetcher.kt
@@ -46,10 +46,11 @@ class EpisodeFetcher(
             val lastFetchTime = settings.getLastEpisodeFetchTime().first()
             val now = clock.now()
             val fetchFromNetwork = forced || now.minus(lastFetchTime) > FETCH_THRESHOLD_HOURS.hours
-            val result = repository.refreshPodcasts(
-                fetchFromNetwork = fetchFromNetwork,
-                systemAllowsAutoDownload = systemAllowsAutoDownload,
-            )
+            val result =
+                repository.refreshPodcasts(
+                    fetchFromNetwork = fetchFromNetwork,
+                    systemAllowsAutoDownload = systemAllowsAutoDownload,
+                )
             if (result is PodcastResult.Failure) {
                 LogHelper.v(TAG, "Failed to fetch podcasts: ${result.error}")
             } else {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/EpisodeFetcher.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/EpisodeFetcher.kt
@@ -33,14 +33,14 @@ class EpisodeFetcher(
                     return@collect
                 }
                 LogHelper.d(TAG, "App in foreground, will fetch episodes if necessary")
-                fetchPodcastsIfNecessary(forced = false, systemAllowsAutoDownload = true)
+                fetchPodcastsIfNecessary(forced = false, episodeDownloadAllowed = true)
             }
         }
     }
 
     suspend fun fetchPodcastsIfNecessary(
         forced: Boolean,
-        systemAllowsAutoDownload: Boolean,
+        episodeDownloadAllowed: Boolean,
     ) {
         refreshPodcastsMutex.withLock {
             val lastFetchTime = settings.getLastEpisodeFetchTime().first()
@@ -49,7 +49,7 @@ class EpisodeFetcher(
             val result =
                 repository.refreshPodcasts(
                     fetchFromNetwork = fetchFromNetwork,
-                    systemAllowsAutoDownload = systemAllowsAutoDownload,
+                    episodeDownloadAllowed = episodeDownloadAllowed,
                 )
             if (result is PodcastResult.Failure) {
                 LogHelper.v(TAG, "Failed to fetch podcasts: ${result.error}")

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
@@ -43,7 +43,7 @@ class SettingsViewModel internal constructor(
     fun fetch() {
         longLivingScope.launch {
             _state.update { it.copy(fetching = true) }
-            episodeFetcher.fetchPodcastsIfNecessary(forced = true, systemAllowsAutoDownload = true)
+            episodeFetcher.fetchPodcastsIfNecessary(forced = true, episodeDownloadAllowed = true)
             _state.update { it.copy(fetching = false) }
         }
     }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
@@ -43,7 +43,7 @@ class SettingsViewModel internal constructor(
     fun fetch() {
         longLivingScope.launch {
             _state.update { it.copy(fetching = true) }
-            episodeFetcher.fetchPodcastsIfNecessary(forced = true)
+            episodeFetcher.fetchPodcastsIfNecessary(forced = true, systemAllowsAutoDownload = true)
             _state.update { it.copy(fetching = false) }
         }
     }


### PR DESCRIPTION
When downloading new episodes in background (from the worker),
episodes are marked as need to be downloaded and not downloaded
right away because of an issue where foreground service (for
download) can not be started from background.
Instead they get downloaded if the app is brought to foreground
or when requesting download from settings.
