### PR TITLE
Fix has new episodes bug

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/PodcastsAndEpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/PodcastsAndEpisodesRepository.kt
@@ -28,7 +28,9 @@ class PodcastsAndEpisodesRepository internal constructor(
     ): PodcastResult<List<Episode>> {
         val result = episodesRepository.refreshForPodcastId(podcastId)
         val episodes = (result as? PodcastResult.Success)?.data ?: listOf()
-        podcastsRepository.updateHasNewEpisodes(podcastId, episodes.isNotEmpty())
+        if (episodes.isNotEmpty()) {
+            podcastsRepository.updateHasNewEpisodes(podcastId, true)
+        }
         if (podcastAllowsAutoDownload) {
             episodes.forEach { episode ->
                 episodesRepository.updateNeedsDownload(id = episode.id, needsDownload = true)


### PR DESCRIPTION
I was clearing podcast has new episodes if no new episodes were fetched
but that reset the indicator if there were new episodes previously
even if user hadn't acknowledged.

Setting the boolean to true if the episode list is not empty (new).
Setting it to false only when user acknowledges it (like before).
