### PR TITLE
Trigger has new seen haptic only if had new

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/home/HomeScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/home/HomeScreen.kt
@@ -66,7 +66,7 @@ fun HomeScreen(
     onSettingsClicked: () -> Unit,
     onImportSubscriptionsClicked: () -> Unit,
     onPodcastClicked: (podcastId: Long) -> Unit,
-    onPodcastHasNewSeen: (podcastId: Long) -> Unit,
+    onPodcastHasNewSeen: (podcastId: Long) -> Boolean,
     onMorePodcastsClicked: () -> Unit,
     onEpisodeClicked: (episodeId: String) -> Unit,
     onEpisodePlayClicked: (episode: Episode) -> Unit,
@@ -104,8 +104,10 @@ fun HomeScreen(
                         podcasts = state.subscribedPodcasts,
                         onPodcastClicked = { onPodcastClicked(it.id) },
                         onPodcastLongClicked = {
-                            onPodcastHasNewSeen(it.id)
-                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                            val hadNewEpisodes = onPodcastHasNewSeen(it.id)
+                            if (hadNewEpisodes) {
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                            }
                         },
                         onMoreClicked = onMorePodcastsClicked,
                     )

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
@@ -53,10 +53,12 @@ class HomeViewModel internal constructor(
         }
     }
 
-    fun markPodcastHasNewSeen(podcastId: Long) {
+    fun markPodcastHasNewSeen(podcastId: Long): Boolean {
+        val hadNewEpisodes = _state.value.subscribedPodcasts.firstOrNull { it.id == podcastId }?.hasNewEpisodes == true
         viewModelScope.launch {
             podcastsRepository.updateHasNewEpisodes(podcastId, false)
         }
+        return hadNewEpisodes
     }
 
     private data class Data(


### PR DESCRIPTION
Earlier was triggering has new seen haptic feedback all the time even
if podcast didn't have the has new indicator. Changed that to only
trigger now if the indicator was present.
