### PR TITLE
Load next page sooner

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/home/HomeScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/home/HomeScreen.kt
@@ -99,9 +99,9 @@ fun HomeScreen(
             derivedStateOf {
                 val lastVisibleItem = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()
                 val totalItemsCount = lazyListState.layoutInfo.totalItemsCount
-                // There is 1 other item above the list of episodes + we want to load more if second last
-                // item from the end is visible, which is why subtracting 3 (1 + 2)
-                lastVisibleItem != null && lastVisibleItem.index >= totalItemsCount - 3
+                // There is 1 other item above the list of episodes + we want to load more if 10th
+                // item from the end is visible, which is why subtracting 11 (1 + 10)
+                lastVisibleItem != null && lastVisibleItem.index >= totalItemsCount - 11
             }
         }
         LaunchedEffect(shouldLoadMoreItems) {

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
@@ -212,9 +212,9 @@ private fun PodcastDetails(
         derivedStateOf {
             val lastVisibleItem = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()
             val totalItemsCount = lazyListState.layoutInfo.totalItemsCount
-            // There is 1 other items in the list above episodes (podcast header) we want to load more if second
-            // last item from the end is visible, which is why subtracting 3 (1 + 2)
-            lastVisibleItem != null && lastVisibleItem.index >= totalItemsCount - 3
+            // There is 1 other items in the list above episodes (podcast header) we want to load more if 10th
+            // item from the end is visible, which is why subtracting 11 (1 + 10)
+            lastVisibleItem != null && lastVisibleItem.index >= totalItemsCount - 11
         }
     }
     LaunchedEffect(shouldLoadMoreItems) {


### PR DESCRIPTION
Earlier was loading when reached the second last item in the list
but loading it when 10 more items to go so that there's less break
in loading more episodes. If the user has reached 90 episodes,
they're probably wanting to load more episodes.
