### PR TITLE
Do not mark has new episodes if loading older

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Circle
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -137,6 +138,7 @@ fun PodcastDetailsScreen(
                 modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
                 hasMorePages = state.hasMorePages,
                 alreadyLoadedEpisodeCount = state.availableEpisodeCount,
+                loadingOlderEpisodes = state.loadingOlderEpisodes,
                 podcastWithEpisodes = podcastWithEpisodes,
                 currentlyPlayingEpisodeId = state.currentlyPlayingEpisodeId,
                 currentlyPlayingEpisodeState = state.playingState,
@@ -175,6 +177,7 @@ fun PodcastDetailsScreen(
 private fun PodcastDetails(
     modifier: Modifier = Modifier,
     hasMorePages: Boolean,
+    loadingOlderEpisodes: Boolean,
     alreadyLoadedEpisodeCount: Long,
     podcastWithEpisodes: PodcastWithSelectableEpisodes,
     currentlyPlayingEpisodeId: String?,
@@ -273,8 +276,9 @@ private fun PodcastDetails(
         if (!hasMorePages) {
             item {
                 LoadEvenOlderEpisodesButton(
+                    loadingOlderEpisodes = loadingOlderEpisodes,
                     alreadyLoadedCount = alreadyLoadedEpisodeCount,
-                    onLoadMoreRequested = onLoadOlderEpisodesRequested,
+                    onLoadOlderEpisodesRequested = onLoadOlderEpisodesRequested,
                 )
             }
         }
@@ -286,8 +290,9 @@ private fun PodcastDetails(
 
 @Composable
 private fun LoadEvenOlderEpisodesButton(
+    loadingOlderEpisodes: Boolean,
     alreadyLoadedCount: Long,
-    onLoadMoreRequested: (Long) -> Unit,
+    onLoadOlderEpisodesRequested: (Long) -> Unit,
 ) {
     var showLoadEvenOlderEpisodesDialog by remember { mutableStateOf(false) }
     var enteredLoadMoreCount by remember { mutableStateOf("") }
@@ -298,7 +303,11 @@ private fun LoadEvenOlderEpisodesButton(
     ) {
         Spacer(modifier = Modifier.height(16.dp))
         OutlinedButton(onClick = { showLoadEvenOlderEpisodesDialog = true }) {
-            Text(text = stringResource(id = R.string.podcast_details_load_even_older_episodes))
+            if (loadingOlderEpisodes) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp))
+            } else {
+                Text(text = stringResource(id = R.string.podcast_details_load_even_older_episodes))
+            }
         }
     }
     if (showLoadEvenOlderEpisodesDialog) {
@@ -358,7 +367,7 @@ private fun LoadEvenOlderEpisodesButton(
                         TextButton(
                             onClick = {
                                 showLoadEvenOlderEpisodesDialog = false
-                                onLoadMoreRequested(enteredLoadMoreCount.toLongOrNull() ?: 0)
+                                onLoadOlderEpisodesRequested(enteredLoadMoreCount.toLongOrNull() ?: 0)
                                 enteredLoadMoreCount = ""
                             },
                         ) {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/ui/PodcastDetailsViewState.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/ui/PodcastDetailsViewState.kt
@@ -13,6 +13,7 @@ data class PodcastDetailsViewState(
     val page: Long = 1,
     val availableEpisodeCount: Long = 0,
     val hasMorePages: Boolean = true,
+    val loadingOlderEpisodes: Boolean = false,
 ) {
     val episodeSortOrder: EpisodeSortOrder
         get() = podcastWithEpisodes?.podcast?.episodeSortOrder ?: EpisodeSortOrder.default

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
@@ -21,8 +21,8 @@ class EpisodesRepository internal constructor(
     private val episodesApi: EpisodesApi,
     private val settings: Settings,
 ) {
-    // Should be called via PodcastsAndEpisodesRepository because that does other things like marking podcasts
-    // having new episodes
+    // Should be called via PodcastsAndEpisodesRepository when necessary because that does other things like
+    // marking podcasts having new episodes
     suspend fun refreshForPodcastId(
         podcastId: Long,
         episodesToLoad: Long = 100,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/PodcastDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/PodcastDetailsViewModel.kt
@@ -213,11 +213,14 @@ class PodcastDetailsViewModel(
         val currentCount = _state.value.availableEpisodeCount
         val episodesToLoadCount = currentCount + additionalCount
         longLivingScope.launch {
-            podcastsAndEpisodesRepository.refreshPodcast(
+            _state.update { it.copy(loadingOlderEpisodes = true) }
+            episodesRepository.refreshForPodcastId(
                 podcastId = podcastId,
                 episodesToLoad = episodesToLoadCount,
                 fetchSinceMostRecentEpisode = false,
             )
+            _state.update { it.copy(loadingOlderEpisodes = false) }
+            onNextPageRequested()
         }
     }
 


### PR DESCRIPTION
When loading older episodes, the podcast would get marked as has new
episodes true but that doesn't seem necessary if user is intentionally
getting older episodes.

Also loading the next page in podcast details screen when loading
older episodes finishes.
