### PR TITLE
Fix seek on app first start

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PlayerControllerImpl.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PlayerControllerImpl.kt
@@ -2,6 +2,7 @@ package com.ramitsuri.podcasts.android.media
 
 import android.content.ComponentName
 import android.content.Context
+import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.ListenableFuture
@@ -59,6 +60,10 @@ class PlayerControllerImpl(
     }
 
     override fun seek(to: Duration) {
+        if (controller?.isCommandAvailable(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM) != true) {
+            LogHelper.d(TAG, "Seek requested but not allowed")
+            return
+        }
         val newPosition = to.inWholeMilliseconds
         controller?.seekTo(newPosition)
     }

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerViewModel.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerViewModel.kt
@@ -9,6 +9,7 @@ import com.ramitsuri.podcasts.model.ui.SleepTimer
 import com.ramitsuri.podcasts.player.PlayerController
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings
+import com.ramitsuri.podcasts.utils.LogHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -37,6 +38,7 @@ class PlayerViewModel(
     val state = _state.asStateFlow()
 
     private var updateEpisodeStateJob: Job? = null
+    private var updateSeekJob: Job? = null
 
     init {
         viewModelScope.launch {
@@ -107,9 +109,23 @@ class PlayerViewModel(
     }
 
     fun onSeekRequested(toPercentOfDuration: Float) {
-        val duration = _state.value.totalDuration
-        if (duration != null) {
-            playerController.seek(duration.times(toPercentOfDuration.toDouble()))
+        _state.update { it.copy(tempPlayProgress = toPercentOfDuration) }
+        updateSeekJob?.cancel()
+        updateSeekJob = viewModelScope.launch {
+            delay(300)
+            val state = _state.value
+            val duration = state.totalDuration
+            if (duration == null) {
+                LogHelper.v(TAG, "Seek requested but no duration")
+                return@launch
+            }
+            val playProgress = duration.times(toPercentOfDuration.toDouble())
+            val episodeId = state.episodeId
+            if (episodeId != null) {
+                episodesRepository.updatePlayProgress(episodeId, playProgress.inWholeSeconds.toInt())
+            }
+            playerController.seek(playProgress)
+            _state.update { it.copy(tempPlayProgress = null) }
         }
     }
 
@@ -244,6 +260,8 @@ class PlayerViewModel(
     )
 
     companion object {
+        private const val TAG = "PlayerViewModel"
+
         fun factory(): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory, KoinComponent {
                 @Suppress("UNCHECKED_CAST")

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/ui/PlayerViewState.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/ui/PlayerViewState.kt
@@ -13,6 +13,7 @@ data class PlayerViewState(
     val playbackSpeed: Float = 1f,
     val isCasting: Boolean = false,
     val trimSilence: Boolean = false,
+    val tempPlayProgress: Float? = null,
 ) {
     val episodeId
         get() = episode?.id
@@ -49,8 +50,8 @@ data class PlayerViewState(
             }
 
     val progress
-        get() =
-            if (episode?.isCompleted == true) {
+        get() = tempPlayProgress
+            ?: if (episode?.isCompleted == true) {
                 1f
             } else {
                 val durationForProgress = (episode?.duration?.toFloat() ?: 1f).coerceAtLeast(1f)


### PR DESCRIPTION
When app first starts, controller for some reason doesn't allow
seeking even though the media is set on the controller.
As a workaround, setting progress in database which should then
ultimately update the UI
