### PR TITLE
Fix delete completed episode timing bug

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
@@ -171,10 +171,10 @@ class EpisodesRepository internal constructor(
                 Episode(dbEpisode)
             }
             .filter { episode ->
-                val downloadAtTime = episode.downloadedAt ?: return@filter false
-                if (episode.isCompleted) {
-                    now.minus(downloadAtTime) >= removeCompletedAfter.duration
-                } else {
+                if (episode.completedAt != null) { // Completed episode
+                    now.minus(episode.completedAt) >= removeCompletedAfter.duration
+                } else { // Not completed episode
+                    val downloadAtTime = episode.downloadedAt ?: return@filter false
                     now.minus(downloadAtTime) >= removeUnfinishedAfter.duration
                 }
             }


### PR DESCRIPTION
Earlier was using downloaded at time for deleting completed episodes
instead of completed at time. So an episode which was just completed
but downloaded more time than the "delete completed episodes after"
setting, would get deleted instantly.
