### PR TITLE
Fix replay and skip on app first start

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PlayerControllerImpl.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PlayerControllerImpl.kt
@@ -45,26 +45,12 @@ class PlayerControllerImpl(
         controller?.pause()
     }
 
-    override fun replay(by: Duration) {
-        controller?.let {
-            val newPosition = (it.currentPosition - by.inWholeMilliseconds).coerceAtLeast(0)
-            it.seekTo(newPosition)
-        }
-    }
-
-    override fun skip(by: Duration) {
-        controller?.let {
-            val newPosition = (it.currentPosition + by.inWholeMilliseconds).coerceAtMost(it.duration)
-            it.seekTo(newPosition)
-        }
-    }
-
     override fun seek(to: Duration) {
         if (controller?.isCommandAvailable(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM) != true) {
             LogHelper.d(TAG, "Seek requested but not allowed")
             return
         }
-        val newPosition = to.inWholeMilliseconds
+        val newPosition = to.inWholeMilliseconds.coerceIn(0, controller?.duration ?: 0)
         controller?.seekTo(newPosition)
     }
 

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/player/PlayerController.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/player/PlayerController.kt
@@ -12,9 +12,5 @@ interface PlayerController {
 
     fun pause()
 
-    fun replay(by: Duration)
-
-    fun skip(by: Duration)
-
     fun seek(to: Duration)
 }


### PR DESCRIPTION
When seek on seekbar was fixed, didn't fix seeking with -10 and +30
buttons. This fixes that.
