### PR TITLE
Fix seek + skip, replay when episode completed

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PodcastMediaSessionService.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PodcastMediaSessionService.kt
@@ -172,10 +172,14 @@ class PodcastMediaSessionService : MediaSessionService(), KoinComponent {
                     }
                 }
                 while (true) {
-                    val episodeId = player?.currentMediaItem?.mediaId ?: break
-                    val progressInSeconds = player.currentPosition.div(1000)
-                    if (progressInSeconds != 0L) {
-                        episodesRepository.updatePlayProgress(episodeId, progressInSeconds.toInt())
+                    if (player != null && player.isPlaying &&
+                        currentEpisode != null && !currentEpisode.isCompleted &&
+                        player.currentMediaItem?.mediaId == currentEpisode.id
+                    ) {
+                        val progressInSeconds = player.currentPosition.div(1000)
+                        if (progressInSeconds != 0L) {
+                            episodesRepository.updatePlayProgress(currentEpisode.id, progressInSeconds.toInt())
+                        }
                     }
                     delay(1.seconds)
                 }

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerViewModel.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerViewModel.kt
@@ -107,6 +107,9 @@ class PlayerViewModel(
                 LogHelper.v(TAG, "Skip requested but episode is null")
                 return@launch
             }
+            if (episode.isCompleted) {
+                episodesRepository.markNotPlayed(episode.id)
+            }
             val newPlayProgress = episode.progressInSeconds.seconds + by
             episodesRepository.updatePlayProgress(episode.id, newPlayProgress.inWholeSeconds.toInt())
             playerController.seek(newPlayProgress)
@@ -120,6 +123,9 @@ class PlayerViewModel(
             if (episode == null) {
                 LogHelper.v(TAG, "Replay requested but episode is null")
                 return@launch
+            }
+            if (episode.isCompleted) {
+                episodesRepository.markNotPlayed(episode.id)
             }
             val newPlayProgress = episode.progressInSeconds.seconds - by
             episodesRepository.updatePlayProgress(episode.id, newPlayProgress.inWholeSeconds.toInt())
@@ -143,6 +149,9 @@ class PlayerViewModel(
                 if (duration == null) {
                     LogHelper.v(TAG, "Seek requested but no duration")
                     return@launch
+                }
+                if (episode.isCompleted) {
+                    episodesRepository.markNotPlayed(episode.id)
                 }
                 val playProgress = duration.times(toPercentOfDuration.toDouble())
                 episodesRepository.updatePlayProgress(episode.id, playProgress.inWholeSeconds.toInt())

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
@@ -264,8 +264,13 @@ class EpisodesRepository internal constructor(
     }
 
     suspend fun markPlayed(id: String) {
+        val episode = getEpisode(id)
+        if (episode == null) {
+            LogHelper.v(TAG, "Episode with id $id not found")
+            return
+        }
         updateCompletedAt(id)
-        updatePlayProgress(id, Episode.PLAY_PROGRESS_MAX)
+        updatePlayProgress(id, episode.duration ?: Episode.PLAY_PROGRESS_MAX)
         updateQueuePositions(mapOf(id to Episode.NOT_IN_QUEUE))
     }
 


### PR DESCRIPTION
Epsiode seeking was still broken when episode was marked as completed
because played duration was being set to max if completed. When
adjusting seek or using skip/replay on a completed episode, it's
now first marked as not completed.
