### PR TITLE
Fix queue rearrangement

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/EpisodesDaoImpl.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/EpisodesDaoImpl.kt
@@ -210,7 +210,10 @@ internal class EpisodesDaoImpl(
         }
     }
 
-    override suspend fun updateQueuePosition(id: String, position: Int) {
+    override suspend fun updateQueuePosition(
+        id: String,
+        position: Int,
+    ) {
         withContext(ioDispatcher) {
             episodeAdditionalInfoEntityQueries.updateQueuePosition(id = id, queuePosition = position)
         }
@@ -220,7 +223,7 @@ internal class EpisodesDaoImpl(
         id1: String,
         position1: Int,
         id2: String,
-        position2: Int
+        position2: Int,
     ) {
         withContext(ioDispatcher) {
             episodeAdditionalInfoEntityQueries.updateQueuePositions(

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/EpisodesDaoImpl.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/EpisodesDaoImpl.kt
@@ -210,13 +210,25 @@ internal class EpisodesDaoImpl(
         }
     }
 
-    override suspend fun updateQueuePositions(idToQueuePosition: Map<String, Int>) {
+    override suspend fun updateQueuePosition(id: String, position: Int) {
         withContext(ioDispatcher) {
-            episodeEntityQueries.transaction {
-                idToQueuePosition.forEach { (id, position) ->
-                    updateQueuePosition(id, position)
-                }
-            }
+            episodeAdditionalInfoEntityQueries.updateQueuePosition(id = id, queuePosition = position)
+        }
+    }
+
+    override suspend fun updateQueuePositions(
+        id1: String,
+        position1: Int,
+        id2: String,
+        position2: Int
+    ) {
+        withContext(ioDispatcher) {
+            episodeAdditionalInfoEntityQueries.updateQueuePositions(
+                id1 = id1,
+                position1 = position1,
+                id2 = id2,
+                position2 = position2,
+            )
         }
     }
 
@@ -259,13 +271,6 @@ internal class EpisodesDaoImpl(
         withContext(ioDispatcher) {
             episodeAdditionalInfoEntityQueries.updateFavorite(id = id, isFavorite = isFavorite)
         }
-    }
-
-    private fun updateQueuePosition(
-        id: String,
-        position: Int,
-    ) {
-        episodeAdditionalInfoEntityQueries.updateQueuePosition(id = id, queuePosition = position)
     }
 
     override suspend fun updateNeedsDownload(

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/interfaces/EpisodesDao.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/interfaces/EpisodesDao.kt
@@ -82,9 +82,17 @@ internal interface EpisodesDao {
         downloadedAt: Instant?,
     )
 
-    suspend fun updateQueuePosition(id: String, position: Int)
+    suspend fun updateQueuePosition(
+        id: String,
+        position: Int,
+    )
 
-    suspend fun updateQueuePositions(id1: String,  position1: Int, id2: String, position2: Int)
+    suspend fun updateQueuePositions(
+        id1: String,
+        position1: Int,
+        id2: String,
+        position2: Int,
+    )
 
     suspend fun updateFavorite(
         id: String,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/interfaces/EpisodesDao.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/interfaces/EpisodesDao.kt
@@ -82,7 +82,9 @@ internal interface EpisodesDao {
         downloadedAt: Instant?,
     )
 
-    suspend fun updateQueuePositions(idToQueuePosition: Map<String, Int>)
+    suspend fun updateQueuePosition(id: String, position: Int)
+
+    suspend fun updateQueuePositions(id1: String,  position1: Int, id2: String, position2: Int)
 
     suspend fun updateFavorite(
         id: String,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
@@ -236,7 +236,7 @@ class EpisodesRepository internal constructor(
         id1: String,
         position1: Int,
         id2: String,
-        position2: Int
+        position2: Int,
     ) {
         episodesDao.updateQueuePositions(
             id1 = id1,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
@@ -232,8 +232,18 @@ class EpisodesRepository internal constructor(
         episodesDao.updateDownloadedAt(id, downloadedAt)
     }
 
-    suspend fun updateQueuePositions(idToPositionMap: Map<String, Int>) {
-        episodesDao.updateQueuePositions(idToPositionMap)
+    suspend fun updateQueuePositions(
+        id1: String,
+        position1: Int,
+        id2: String,
+        position2: Int
+    ) {
+        episodesDao.updateQueuePositions(
+            id1 = id1,
+            position1 = position1,
+            id2 = id2,
+            position2 = position2,
+        )
     }
 
     suspend fun addToQueue(id: String) {
@@ -241,7 +251,7 @@ class EpisodesRepository internal constructor(
     }
 
     suspend fun removeFromQueue(id: String) {
-        updateQueuePositions(mapOf(id to Episode.NOT_IN_QUEUE))
+        episodesDao.updateQueuePosition(id, Episode.NOT_IN_QUEUE)
     }
 
     private suspend fun updateCompletedAt(
@@ -280,7 +290,7 @@ class EpisodesRepository internal constructor(
         }
         updateCompletedAt(id)
         updatePlayProgress(id, episode.duration ?: Episode.PLAY_PROGRESS_MAX)
-        updateQueuePositions(mapOf(id to Episode.NOT_IN_QUEUE))
+        removeFromQueue(id)
     }
 
     suspend fun markNotPlayed(id: String) {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -46,18 +46,16 @@ class QueueViewModel internal constructor(
     }
 
     fun onEpisodeRearrangementRequested(
-        from: Int,
-        to: Int,
+        position1: Int,
+        position2: Int,
     ) {
         viewModelScope.launch {
-            val currentlyAtFrom = _state.value.episodes.getOrNull(from)
-            val currentlyAtTo = _state.value.episodes.getOrNull(to)
-            if (currentlyAtFrom != null && currentlyAtTo != null) {
+            val currentlyAtPosition1 = _state.value.episodes.getOrNull(position1)
+            val currentlyAtPosition2 = _state.value.episodes.getOrNull(position2)
+            if (currentlyAtPosition1 != null && currentlyAtPosition2 != null) {
                 episodesRepository.updateQueuePositions(
-                    mapOf(
-                        currentlyAtFrom.id to to,
-                        currentlyAtTo.id to from,
-                    ),
+                    currentlyAtPosition1.id, currentlyAtPosition2.queuePosition,
+                    currentlyAtPosition2.id, currentlyAtPosition1.queuePosition,
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -54,8 +54,10 @@ class QueueViewModel internal constructor(
             val currentlyAtPosition2 = _state.value.episodes.getOrNull(position2)
             if (currentlyAtPosition1 != null && currentlyAtPosition2 != null) {
                 episodesRepository.updateQueuePositions(
-                    currentlyAtPosition1.id, currentlyAtPosition2.queuePosition,
-                    currentlyAtPosition2.id, currentlyAtPosition1.queuePosition,
+                    currentlyAtPosition1.id,
+                    currentlyAtPosition2.queuePosition,
+                    currentlyAtPosition2.id,
+                    currentlyAtPosition1.queuePosition,
                 )
             }
         }

--- a/shared/src/commonMain/sqldelight/com/ramitsuri/podcasts/EpisodeAdditionalInfoEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/ramitsuri/podcasts/EpisodeAdditionalInfoEntity.sq
@@ -57,6 +57,14 @@ UPDATE EpisodeAdditionalInfoEntity
 SET queuePosition = :queuePosition
 WHERE id = :id;
 
+updateQueuePositions:
+UPDATE EpisodeAdditionalInfoEntity
+SET queuePosition = CASE id
+                    WHEN :id1 THEN :position1
+                    WHEN :id2 THEN :position2
+                    END
+WHERE id = :id1 OR id = :id2;
+
 updateFavorite:
 UPDATE EpisodeAdditionalInfoEntity
 SET isFavorite = :isFavorite

--- a/shared/src/jvmTest/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepositoryTest.kt
+++ b/shared/src/jvmTest/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepositoryTest.kt
@@ -30,38 +30,42 @@ class EpisodesRepositoryTest : BaseTest() {
         }
 
     @Test
-    fun testSwapQueuePositions() = runBlocking {
-        // Arrange
-        insert(id = "1", queuePosition = 1)
-        insert(id = "2", queuePosition = 2)
-        insert(id = "3", queuePosition = 3)
-        insert(id = "4", queuePosition = 4)
-        insert(id = "5", queuePosition = 5)
+    fun testSwapQueuePositions() =
+        runBlocking {
+            // Arrange
+            insert(id = "1", queuePosition = 1)
+            insert(id = "2", queuePosition = 2)
+            insert(id = "3", queuePosition = 3)
+            insert(id = "4", queuePosition = 4)
+            insert(id = "5", queuePosition = 5)
 
-        // Act
-        // Assert
-        assertQueueOrder("1", "2", "3", "4", "5")
+            // Act
+            // Assert
+            assertQueueOrder("1", "2", "3", "4", "5")
 
-        swapQueuePositions("1", "2")
-        assertQueueOrder("2", "1", "3", "4", "5")
+            swapQueuePositions("1", "2")
+            assertQueueOrder("2", "1", "3", "4", "5")
 
-        swapQueuePositions("3","4",)
-        assertQueueOrder("2", "1", "4", "3", "5")
+            swapQueuePositions("3", "4")
+            assertQueueOrder("2", "1", "4", "3", "5")
 
-        swapQueuePositions("1","5",)
-        assertQueueOrder("2", "5", "4", "3", "1")
+            swapQueuePositions("1", "5")
+            assertQueueOrder("2", "5", "4", "3", "1")
 
-        swapQueuePositions("2","1",)
-        assertQueueOrder("1", "5", "4", "3", "2")
+            swapQueuePositions("2", "1")
+            assertQueueOrder("1", "5", "4", "3", "2")
 
-        swapQueuePositions("1","2",)
-        assertQueueOrder("2", "5", "4", "3", "1")
+            swapQueuePositions("1", "2")
+            assertQueueOrder("2", "5", "4", "3", "1")
 
-        swapQueuePositions("5","4",)
-        assertQueueOrder("2", "4", "5", "3", "1")
-    }
+            swapQueuePositions("5", "4")
+            assertQueueOrder("2", "4", "5", "3", "1")
+        }
 
-    private suspend fun swapQueuePositions(id1: String, id2: String) {
+    private suspend fun swapQueuePositions(
+        id1: String,
+        id2: String,
+    ) {
         val repo = get<EpisodesRepository>()
         val episodes = repo.getQueue()
         val pos1 = episodes.indexOfFirst { it.id == id1 }
@@ -69,9 +73,11 @@ class EpisodesRepositoryTest : BaseTest() {
         val currentlyAtPosition1 = episodes[pos1]
         val currentlyAtPosition2 = episodes[pos2]
         repo.updateQueuePositions(
-                currentlyAtPosition1.id, currentlyAtPosition2.queuePosition,
-                currentlyAtPosition2.id, currentlyAtPosition1.queuePosition,
-            )
+            currentlyAtPosition1.id,
+            currentlyAtPosition2.queuePosition,
+            currentlyAtPosition2.id,
+            currentlyAtPosition1.queuePosition,
+        )
     }
 
     private suspend fun assertQueueOrder(vararg ids: String) {

--- a/shared/src/jvmTest/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepositoryTest.kt
+++ b/shared/src/jvmTest/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepositoryTest.kt
@@ -29,9 +29,60 @@ class EpisodesRepositoryTest : BaseTest() {
             assertEquals(listOf(1L), result)
         }
 
+    @Test
+    fun testSwapQueuePositions() = runBlocking {
+        // Arrange
+        insert(id = "1", queuePosition = 1)
+        insert(id = "2", queuePosition = 2)
+        insert(id = "3", queuePosition = 3)
+        insert(id = "4", queuePosition = 4)
+        insert(id = "5", queuePosition = 5)
+
+        // Act
+        // Assert
+        assertQueueOrder("1", "2", "3", "4", "5")
+
+        swapQueuePositions("1", "2")
+        assertQueueOrder("2", "1", "3", "4", "5")
+
+        swapQueuePositions("3","4",)
+        assertQueueOrder("2", "1", "4", "3", "5")
+
+        swapQueuePositions("1","5",)
+        assertQueueOrder("2", "5", "4", "3", "1")
+
+        swapQueuePositions("2","1",)
+        assertQueueOrder("1", "5", "4", "3", "2")
+
+        swapQueuePositions("1","2",)
+        assertQueueOrder("2", "5", "4", "3", "1")
+
+        swapQueuePositions("5","4",)
+        assertQueueOrder("2", "4", "5", "3", "1")
+    }
+
+    private suspend fun swapQueuePositions(id1: String, id2: String) {
+        val repo = get<EpisodesRepository>()
+        val episodes = repo.getQueue()
+        val pos1 = episodes.indexOfFirst { it.id == id1 }
+        val pos2 = episodes.indexOfFirst { it.id == id2 }
+        val currentlyAtPosition1 = episodes[pos1]
+        val currentlyAtPosition2 = episodes[pos2]
+        repo.updateQueuePositions(
+                currentlyAtPosition1.id, currentlyAtPosition2.queuePosition,
+                currentlyAtPosition2.id, currentlyAtPosition1.queuePosition,
+            )
+    }
+
+    private suspend fun assertQueueOrder(vararg ids: String) {
+        val repo = get<EpisodesRepository>()
+        assertEquals(ids.toList(), repo.getQueue().map { it.id })
+    }
+
     private suspend fun insert(
         id: String,
-        podcastId: Long,
+        podcastId: Long = 1,
+        queuePosition: Int = 0,
     ) {
         get<PodcastsDao>().insert(
             listOf(
@@ -84,7 +135,7 @@ class EpisodesRepositoryTest : BaseTest() {
                     downloadProgress = 0.0,
                     downloadBlocked = false,
                     downloadedAt = null,
-                    queuePosition = 0,
+                    queuePosition = queuePosition,
                     completedAt = null,
                     isFavorite = false,
                     needsDownload = false,


### PR DESCRIPTION
When changing queue positions, was using the index of the item in the
queue list when it should've been the other item's queuePosition that
was being switched.

Also added a new SQL query to update queuePosition for 2 items at once
