### PR TITLE
Skip player release on PlayerScreen decomposition

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
@@ -162,7 +162,7 @@ fun NavGraph(
                             playerViewModel.initializePlayer()
 
                             onStopOrDispose {
-                                playerViewModel.releasePlayer()
+                                // Do nothing
                             }
                         }
                         PlayerScreen(

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerViewModel.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerViewModel.kt
@@ -248,10 +248,6 @@ class PlayerViewModel(
         playerController.initializePlayer()
     }
 
-    fun releasePlayer() {
-        playerController.releasePlayer()
-    }
-
     private fun updateSleepTimerDuration() {
         when (val sleepTimer = _state.value.sleepTimer) {
             is SleepTimer.Custom -> {


### PR DESCRIPTION
Ever since aligned player lifecycle to PlayerScreen lifecycle, the
player is removed much sooner from the notification panel than
expected. Removing the release player call so that it can stay there
for longer.
