### PR TITLE
Fix image not loading in some cases

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/components/AsyncImage.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/components/AsyncImage.kt
@@ -1,0 +1,28 @@
+package com.ramitsuri.podcasts.android.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+
+@Composable
+fun Image(
+    url: String,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.FillBounds,
+) {
+    AsyncImage(
+        model =
+        ImageRequest.Builder(LocalContext.current)
+            .setHeader("User-Agent", "Podcasts")
+            .data(url)
+            .crossfade(true)
+            .build(),
+        contentDescription = contentDescription,
+        contentScale = contentScale,
+        modifier = modifier,
+    )
+}

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/components/AsyncImage.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/components/AsyncImage.kt
@@ -16,11 +16,11 @@ fun Image(
 ) {
     AsyncImage(
         model =
-        ImageRequest.Builder(LocalContext.current)
-            .setHeader("User-Agent", "Podcasts")
-            .data(url)
-            .crossfade(true)
-            .build(),
+            ImageRequest.Builder(LocalContext.current)
+                .setHeader("User-Agent", "Podcasts")
+                .data(url)
+                .crossfade(true)
+                .build(),
         contentDescription = contentDescription,
         contentScale = contentScale,
         modifier = modifier,

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/components/EpisodeItem.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/components/EpisodeItem.kt
@@ -16,11 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.ramitsuri.podcasts.android.utils.friendlyPublishDate
 import com.ramitsuri.podcasts.model.Episode
 import com.ramitsuri.podcasts.model.PlayingState
@@ -76,14 +72,9 @@ fun EpisodeItem(
 @Composable
 private fun EpisodeInfo(episode: Episode) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        AsyncImage(
-            model =
-                ImageRequest.Builder(LocalContext.current)
-                    .data(episode.podcastImageUrl)
-                    .crossfade(true)
-                    .build(),
+        Image(
+            url = episode.podcastImageUrl,
             contentDescription = episode.title,
-            contentScale = ContentScale.FillBounds,
             modifier =
                 Modifier
                     .clip(MaterialTheme.shapes.extraSmall)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/components/PodcastInfoItem.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/components/PodcastInfoItem.kt
@@ -14,12 +14,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.ramitsuri.podcasts.android.ui.PreviewTheme
 import com.ramitsuri.podcasts.android.ui.ThemePreview
 import com.ramitsuri.podcasts.model.Podcast
@@ -49,14 +45,9 @@ fun PodcastInfoItem(
 @Composable
 fun PodcastInfo(podcast: Podcast) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        AsyncImage(
-            model =
-                ImageRequest.Builder(LocalContext.current)
-                    .data(podcast.artwork)
-                    .crossfade(true)
-                    .build(),
+        Image(
+            url = podcast.artwork,
             contentDescription = podcast.title,
-            contentScale = ContentScale.FillBounds,
             modifier =
                 Modifier
                     .clip(MaterialTheme.shapes.small)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/episode/EpisodeDetailsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/episode/EpisodeDetailsScreen.kt
@@ -24,8 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.SpanStyle
@@ -34,11 +32,10 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import be.digitalia.compose.htmlconverter.HtmlStyle
 import be.digitalia.compose.htmlconverter.htmlToAnnotatedString
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.ramitsuri.podcasts.android.ui.PreviewTheme
 import com.ramitsuri.podcasts.android.ui.ThemePreview
 import com.ramitsuri.podcasts.android.ui.components.EpisodeControls
+import com.ramitsuri.podcasts.android.ui.components.Image
 import com.ramitsuri.podcasts.android.ui.components.TopAppBar
 import com.ramitsuri.podcasts.android.ui.components.episode
 import com.ramitsuri.podcasts.android.utils.friendlyPublishDate
@@ -118,14 +115,9 @@ private fun EpisodeDetails(
     ) {
         Spacer(modifier = Modifier.height(8.dp))
         Row(modifier = Modifier.fillMaxWidth()) {
-            AsyncImage(
-                model =
-                    ImageRequest.Builder(LocalContext.current)
-                        .data(episode.podcastImageUrl)
-                        .crossfade(true)
-                        .build(),
+            Image(
+                url = episode.podcastImageUrl,
                 contentDescription = episode.title,
-                contentScale = ContentScale.FillBounds,
                 modifier =
                     Modifier
                         .clip(MaterialTheme.shapes.small)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/home/HomeScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/home/HomeScreen.kt
@@ -38,8 +38,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -47,14 +45,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import be.digitalia.compose.htmlconverter.htmlToString
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.ramitsuri.podcasts.android.R
 import com.ramitsuri.podcasts.android.ui.PreviewTheme
 import com.ramitsuri.podcasts.android.ui.ThemePreview
 import com.ramitsuri.podcasts.android.ui.components.CenteredTitleTopAppBar
 import com.ramitsuri.podcasts.android.ui.components.ColoredHorizontalDivider
 import com.ramitsuri.podcasts.android.ui.components.EpisodeControls
+import com.ramitsuri.podcasts.android.ui.components.Image
 import com.ramitsuri.podcasts.android.ui.components.episode
 import com.ramitsuri.podcasts.android.ui.components.podcast
 import com.ramitsuri.podcasts.android.utils.friendlyPublishDate
@@ -239,14 +236,9 @@ private fun SubscribedPodcastItem(
                     onLongClick = onLongClicked,
                 ),
     ) {
-        AsyncImage(
-            model =
-                ImageRequest.Builder(LocalContext.current)
-                    .data(artwork)
-                    .crossfade(true)
-                    .build(),
+        Image(
+            url = artwork,
             contentDescription = title,
-            contentScale = ContentScale.FillBounds,
             modifier =
                 Modifier
                     .size(88.dp)
@@ -291,14 +283,9 @@ private fun EpisodeItem(
                 .padding(horizontal = 16.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            AsyncImage(
-                model =
-                    ImageRequest.Builder(LocalContext.current)
-                        .data(episode.podcastImageUrl)
-                        .crossfade(true)
-                        .build(),
+            Image(
+                url = episode.podcastImageUrl,
                 contentDescription = episode.title,
-                contentScale = ContentScale.FillBounds,
                 modifier =
                     Modifier
                         .clip(MaterialTheme.shapes.extraSmall)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/library/queue/QueueScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/library/queue/QueueScreen.kt
@@ -34,19 +34,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.ramitsuri.podcasts.android.R
 import com.ramitsuri.podcasts.android.ui.PreviewTheme
 import com.ramitsuri.podcasts.android.ui.ThemePreview
 import com.ramitsuri.podcasts.android.ui.components.ColoredHorizontalDivider
 import com.ramitsuri.podcasts.android.ui.components.EpisodeControls
+import com.ramitsuri.podcasts.android.ui.components.Image
 import com.ramitsuri.podcasts.android.ui.components.TopAppBar
 import com.ramitsuri.podcasts.android.ui.components.episode
 import com.ramitsuri.podcasts.android.utils.friendlyPublishDate
@@ -223,14 +220,9 @@ private fun LazyItemScope.EpisodeItem(
 @Composable
 private fun EpisodeInfo(episode: Episode) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        AsyncImage(
-            model =
-                ImageRequest.Builder(LocalContext.current)
-                    .data(episode.podcastImageUrl)
-                    .crossfade(true)
-                    .build(),
+        Image(
+            url = episode.podcastImageUrl,
             contentDescription = episode.title,
-            contentScale = ContentScale.FillBounds,
             modifier =
                 Modifier
                     .clip(MaterialTheme.shapes.extraSmall)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerScreen.kt
@@ -47,20 +47,17 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.view.HapticFeedbackConstantsCompat
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.ramitsuri.podcasts.android.R
 import com.ramitsuri.podcasts.android.ui.PreviewTheme
 import com.ramitsuri.podcasts.android.ui.ThemePreview
+import com.ramitsuri.podcasts.android.ui.components.Image
 import com.ramitsuri.podcasts.android.ui.components.SquigglySlider
 import com.ramitsuri.podcasts.model.PlayingState
 import com.ramitsuri.podcasts.model.ui.PlayerViewState
@@ -202,14 +199,9 @@ private fun PlayerScreenExpanded(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(modifier = Modifier.height(16.dp))
-        AsyncImage(
-            model =
-                ImageRequest.Builder(LocalContext.current)
-                    .data(episodeArtwork)
-                    .crossfade(true)
-                    .build(),
+        Image(
+            url = episodeArtwork,
             contentDescription = episodeTitle,
-            contentScale = ContentScale.FillBounds,
             modifier =
                 Modifier
                     .clip(MaterialTheme.shapes.medium)
@@ -686,14 +678,9 @@ private fun PlayerScreenNotExpanded(
                     .padding(vertical = 4.dp, horizontal = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            AsyncImage(
-                model =
-                    ImageRequest.Builder(LocalContext.current)
-                        .data(episodeArtwork)
-                        .crossfade(true)
-                        .build(),
+            Image(
+                url = episodeArtwork,
                 contentDescription = episodeTitle,
-                contentScale = ContentScale.FillBounds,
                 modifier =
                     Modifier
                         .clip(MaterialTheme.shapes.extraSmall)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
@@ -56,8 +56,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -69,14 +67,13 @@ import androidx.core.text.isDigitsOnly
 import androidx.core.view.HapticFeedbackConstantsCompat
 import be.digitalia.compose.htmlconverter.htmlToAnnotatedString
 import be.digitalia.compose.htmlconverter.htmlToString
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.ramitsuri.podcasts.android.BuildConfig
 import com.ramitsuri.podcasts.android.R
 import com.ramitsuri.podcasts.android.ui.PreviewTheme
 import com.ramitsuri.podcasts.android.ui.ThemePreview
 import com.ramitsuri.podcasts.android.ui.components.ColoredHorizontalDivider
 import com.ramitsuri.podcasts.android.ui.components.EpisodeControls
+import com.ramitsuri.podcasts.android.ui.components.Image
 import com.ramitsuri.podcasts.android.ui.components.TopAppBar
 import com.ramitsuri.podcasts.android.ui.components.episode
 import com.ramitsuri.podcasts.android.ui.components.podcast
@@ -588,14 +585,9 @@ private fun PodcastHeader(
 @Composable
 private fun TitleAndImage(podcast: Podcast) {
     Row(modifier = Modifier.fillMaxWidth()) {
-        AsyncImage(
-            model =
-                ImageRequest.Builder(LocalContext.current)
-                    .data(podcast.artwork)
-                    .crossfade(true)
-                    .build(),
+        Image(
+            url =podcast.artwork,
             contentDescription = podcast.title,
-            contentScale = ContentScale.FillBounds,
             modifier =
                 Modifier
                     .clip(MaterialTheme.shapes.small)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
@@ -586,7 +586,7 @@ private fun PodcastHeader(
 private fun TitleAndImage(podcast: Podcast) {
     Row(modifier = Modifier.fillMaxWidth()) {
         Image(
-            url =podcast.artwork,
+            url = podcast.artwork,
             contentDescription = podcast.title,
             modifier =
                 Modifier

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/subscriptions/SubscriptionsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/subscriptions/SubscriptionsScreen.kt
@@ -26,17 +26,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.ramitsuri.podcasts.android.R
 import com.ramitsuri.podcasts.android.ui.PreviewTheme
 import com.ramitsuri.podcasts.android.ui.ThemePreview
+import com.ramitsuri.podcasts.android.ui.components.Image
 import com.ramitsuri.podcasts.android.ui.components.TopAppBar
 import com.ramitsuri.podcasts.android.ui.components.podcast
 import com.ramitsuri.podcasts.model.Podcast
@@ -103,14 +100,9 @@ private fun SubscribedPodcastItem(
                 .clickable(onClick = { onClicked(podcast) }),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        AsyncImage(
-            model =
-                ImageRequest.Builder(LocalContext.current)
-                    .data(podcast.artwork)
-                    .crossfade(true)
-                    .build(),
+        Image(
+            url = podcast.artwork,
             contentDescription = podcast.title,
-            contentScale = ContentScale.FillBounds,
             modifier =
                 Modifier
                     .clip(MaterialTheme.shapes.small)


### PR DESCRIPTION
Turns out that some Coil image download requests fail with 403 because
there's no user agent header in the request.
One such example is https://storage.buzzsprout.com/c9iocudx16ij4espsgtoj5qbq8sk?.jpg

Added a new image component to be used and then adding the header in
there for all requests.
