### PR TITLE
Skip collecting flows in VMs

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/ui/HomeViewState.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/ui/HomeViewState.kt
@@ -9,6 +9,4 @@ data class HomeViewState(
     val episodes: List<Episode> = listOf(),
     val currentlyPlayingEpisodeId: String? = null,
     val currentlyPlayingEpisodeState: PlayingState = PlayingState.NOT_PLAYING,
-    val page: Long = 1,
-    val availableEpisodeCount: Long = 0,
 )

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
@@ -298,7 +298,7 @@ class EpisodesRepository internal constructor(
         updatePlayProgress(id, 0)
     }
 
-    suspend fun getCurrentEpisode(): Flow<Episode?> {
+    fun getCurrentEpisode(): Flow<Episode?> {
         return settings.getCurrentEpisodeId().map { episodeId ->
             episodeId?.let { getEpisode(it) }
         }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/DownloadsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/DownloadsViewModel.kt
@@ -2,18 +2,12 @@ package com.ramitsuri.podcasts.viewmodel
 
 import com.ramitsuri.podcasts.model.PlayingState
 import com.ramitsuri.podcasts.model.ui.DownloadsViewState
-import com.ramitsuri.podcasts.model.ui.HomeViewState
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 
 class DownloadsViewModel internal constructor(
     episodeController: EpisodeController,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/DownloadsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/DownloadsViewModel.kt
@@ -14,21 +14,22 @@ class DownloadsViewModel internal constructor(
     settings: Settings,
     episodesRepository: EpisodesRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-    val state = combine(
-        episodesRepository.getDownloadedFlow(),
-        episodesRepository.getCurrentEpisode(),
-        settings.getPlayingStateFlow(),
-    ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
-        val currentlyPlaying =
-            if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                currentlyPlayingEpisode
-            } else {
-                null
-            }
-        DownloadsViewState(subscribedEpisodes, currentlyPlaying?.id, playingState)
-    }.stateIn(
-        viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = DownloadsViewState(),
-    )
+    val state =
+        combine(
+            episodesRepository.getDownloadedFlow(),
+            episodesRepository.getCurrentEpisode(),
+            settings.getPlayingStateFlow(),
+        ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+            val currentlyPlaying =
+                if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                    currentlyPlayingEpisode
+                } else {
+                    null
+                }
+            DownloadsViewState(subscribedEpisodes, currentlyPlaying?.id, playingState)
+        }.stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = DownloadsViewState(),
+        )
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/DownloadsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/DownloadsViewModel.kt
@@ -2,46 +2,39 @@ package com.ramitsuri.podcasts.viewmodel
 
 import com.ramitsuri.podcasts.model.PlayingState
 import com.ramitsuri.podcasts.model.ui.DownloadsViewState
+import com.ramitsuri.podcasts.model.ui.HomeViewState
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class DownloadsViewModel internal constructor(
     episodeController: EpisodeController,
     settings: Settings,
-    private val episodesRepository: EpisodesRepository,
+    episodesRepository: EpisodesRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-    private val _state = MutableStateFlow(DownloadsViewState())
-    val state = _state.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            combine(
-                episodesRepository.getDownloadedFlow(),
-                episodesRepository.getCurrentEpisode(),
-                settings.getPlayingStateFlow(),
-            ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
-                val currentlyPlaying =
-                    if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                        currentlyPlayingEpisode
-                    } else {
-                        null
-                    }
-                Triple(subscribedEpisodes, currentlyPlaying, playingState)
-            }.collect { (subscribedEpisodes, currentlyPlayingEpisode, playingState) ->
-                _state.update {
-                    it.copy(
-                        episodes = subscribedEpisodes,
-                        currentlyPlayingEpisodeId = currentlyPlayingEpisode?.id,
-                        currentlyPlayingEpisodeState = playingState,
-                    )
-                }
+    val state = combine(
+        episodesRepository.getDownloadedFlow(),
+        episodesRepository.getCurrentEpisode(),
+        settings.getPlayingStateFlow(),
+    ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+        val currentlyPlaying =
+            if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                currentlyPlayingEpisode
+            } else {
+                null
             }
-        }
-    }
+        DownloadsViewState(subscribedEpisodes, currentlyPlaying?.id, playingState)
+    }.stateIn(
+        viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = DownloadsViewState(),
+    )
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeDetailsViewModel.kt
@@ -6,11 +6,9 @@ import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
 import com.ramitsuri.podcasts.utils.LogHelper
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.stateIn
 
 class EpisodeDetailsViewModel internal constructor(
     episodeId: String?,
@@ -18,34 +16,26 @@ class EpisodeDetailsViewModel internal constructor(
     episodeController: EpisodeController,
     settings: Settings,
 ) : ViewModel(), EpisodeController by episodeController {
-    private val _state = MutableStateFlow(EpisodeDetailsViewState())
-    val state = _state.asStateFlow()
+    val state = combine(
+        repository.getEpisodeFlow(episodeId ?: ""),
+        repository.getCurrentEpisode(),
+        settings.getPlayingStateFlow(),
+    ) { episode, currentlyPlayingEpisode, playingState ->
+        val currentlyPlaying =
+            if (episode != null && episode.id == currentlyPlayingEpisode?.id) {
+                playingState
+            } else {
+                PlayingState.NOT_PLAYING
+            }
+        EpisodeDetailsViewState(episode, currentlyPlaying)
+    }.stateIn(
+        viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = EpisodeDetailsViewState(),
+    )
 
     init {
-        if (episodeId != null) {
-            viewModelScope.launch {
-                combine(
-                    repository.getEpisodeFlow(episodeId),
-                    repository.getCurrentEpisode(),
-                    settings.getPlayingStateFlow(),
-                ) { episode, currentlyPlayingEpisode, playingState ->
-                    val currentlyPlaying =
-                        if (episode != null && episode.id == currentlyPlayingEpisode?.id) {
-                            playingState
-                        } else {
-                            PlayingState.NOT_PLAYING
-                        }
-                    Pair(episode, currentlyPlaying)
-                }.collect { (episode, playingState) ->
-                    _state.update {
-                        it.copy(
-                            episode = episode,
-                            playingState = playingState,
-                        )
-                    }
-                }
-            }
-        } else {
+        if (episodeId == null) {
             LogHelper.v(TAG, "Episode id is null")
         }
     }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeDetailsViewModel.kt
@@ -16,23 +16,24 @@ class EpisodeDetailsViewModel internal constructor(
     episodeController: EpisodeController,
     settings: Settings,
 ) : ViewModel(), EpisodeController by episodeController {
-    val state = combine(
-        repository.getEpisodeFlow(episodeId ?: ""),
-        repository.getCurrentEpisode(),
-        settings.getPlayingStateFlow(),
-    ) { episode, currentlyPlayingEpisode, playingState ->
-        val currentlyPlaying =
-            if (episode != null && episode.id == currentlyPlayingEpisode?.id) {
-                playingState
-            } else {
-                PlayingState.NOT_PLAYING
-            }
-        EpisodeDetailsViewState(episode, currentlyPlaying)
-    }.stateIn(
-        viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = EpisodeDetailsViewState(),
-    )
+    val state =
+        combine(
+            repository.getEpisodeFlow(episodeId ?: ""),
+            repository.getCurrentEpisode(),
+            settings.getPlayingStateFlow(),
+        ) { episode, currentlyPlayingEpisode, playingState ->
+            val currentlyPlaying =
+                if (episode != null && episode.id == currentlyPlayingEpisode?.id) {
+                    playingState
+                } else {
+                    PlayingState.NOT_PLAYING
+                }
+            EpisodeDetailsViewState(episode, currentlyPlaying)
+        }.stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = EpisodeDetailsViewState(),
+        )
 
     init {
         if (episodeId == null) {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
@@ -8,11 +8,9 @@ import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.repositories.SessionHistoryRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -24,34 +22,24 @@ class EpisodeHistoryViewModel internal constructor(
     settings: Settings,
     private val timeZone: TimeZone,
 ) : ViewModel(), EpisodeController by episodeController {
-    private val _state = MutableStateFlow(EpisodeHistoryViewState())
-    val state = _state.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            combine(
-                repository.getEpisodeHistory(timeZone),
-                episodesRepository.getCurrentEpisode(),
-                settings.getPlayingStateFlow(),
-            ) { episodeHistories, currentlyPlayingEpisode, playingState ->
-                val currentlyPlaying =
-                    if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                        currentlyPlayingEpisode
-                    } else {
-                        null
-                    }
-                Triple(episodeHistories, currentlyPlaying, playingState)
-            }.collect { (episodeHistories, currentlyPlayingEpisode, playingState) ->
-                _state.update {
-                    it.copy(
-                        episodesByDate = episodeHistories.groupedByDate(),
-                        currentlyPlayingEpisodeId = currentlyPlayingEpisode?.id,
-                        currentlyPlayingEpisodeState = playingState,
-                    )
-                }
+    val state = combine(
+        repository.getEpisodeHistory(timeZone),
+        episodesRepository.getCurrentEpisode(),
+        settings.getPlayingStateFlow(),
+    ) { episodeHistories, currentlyPlayingEpisode, playingState ->
+        val currentlyPlaying =
+            if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                currentlyPlayingEpisode
+            } else {
+                null
             }
-        }
-    }
+        EpisodeHistoryViewState(episodeHistories.groupedByDate(), currentlyPlaying?.id, playingState)
+    }.stateIn(
+        viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = EpisodeHistoryViewState(),
+    )
+
 
     private fun List<EpisodeHistory>.groupedByDate(): Map<LocalDate, List<Episode>> {
         return groupBy { episodeHistory ->

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
@@ -22,24 +22,24 @@ class EpisodeHistoryViewModel internal constructor(
     settings: Settings,
     private val timeZone: TimeZone,
 ) : ViewModel(), EpisodeController by episodeController {
-    val state = combine(
-        repository.getEpisodeHistory(timeZone),
-        episodesRepository.getCurrentEpisode(),
-        settings.getPlayingStateFlow(),
-    ) { episodeHistories, currentlyPlayingEpisode, playingState ->
-        val currentlyPlaying =
-            if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                currentlyPlayingEpisode
-            } else {
-                null
-            }
-        EpisodeHistoryViewState(episodeHistories.groupedByDate(), currentlyPlaying?.id, playingState)
-    }.stateIn(
-        viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = EpisodeHistoryViewState(),
-    )
-
+    val state =
+        combine(
+            repository.getEpisodeHistory(timeZone),
+            episodesRepository.getCurrentEpisode(),
+            settings.getPlayingStateFlow(),
+        ) { episodeHistories, currentlyPlayingEpisode, playingState ->
+            val currentlyPlaying =
+                if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                    currentlyPlayingEpisode
+                } else {
+                    null
+                }
+            EpisodeHistoryViewState(episodeHistories.groupedByDate(), currentlyPlaying?.id, playingState)
+        }.stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = EpisodeHistoryViewState(),
+        )
 
     private fun List<EpisodeHistory>.groupedByDate(): Map<LocalDate, List<Episode>> {
         return groupBy { episodeHistory ->

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/FavoritesViewModel.kt
@@ -5,43 +5,30 @@ import com.ramitsuri.podcasts.model.ui.FavoritesViewState
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.stateIn
 
 class FavoritesViewModel internal constructor(
     episodeController: EpisodeController,
     settings: Settings,
-    private val episodesRepository: EpisodesRepository,
+    episodesRepository: EpisodesRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-    private val _state = MutableStateFlow(FavoritesViewState())
-    val state = _state.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            combine(
-                episodesRepository.getFavoritesFlow(),
-                episodesRepository.getCurrentEpisode(),
-                settings.getPlayingStateFlow(),
-            ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
-                val currentlyPlaying =
-                    if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                        currentlyPlayingEpisode
-                    } else {
-                        null
-                    }
-                Triple(subscribedEpisodes, currentlyPlaying, playingState)
-            }.collect { (subscribedEpisodes, currentlyPlayingEpisode, playingState) ->
-                _state.update {
-                    it.copy(
-                        episodes = subscribedEpisodes,
-                        currentlyPlayingEpisodeId = currentlyPlayingEpisode?.id,
-                        currentlyPlayingEpisodeState = playingState,
-                    )
-                }
+    val state = combine(
+        episodesRepository.getFavoritesFlow(),
+        episodesRepository.getCurrentEpisode(),
+        settings.getPlayingStateFlow(),
+    ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+        val currentlyPlaying =
+            if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                currentlyPlayingEpisode
+            } else {
+                null
             }
-        }
-    }
+        FavoritesViewState(subscribedEpisodes, currentlyPlaying?.id, playingState)
+    }.stateIn(
+        viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = FavoritesViewState(),
+    )
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/FavoritesViewModel.kt
@@ -14,21 +14,22 @@ class FavoritesViewModel internal constructor(
     settings: Settings,
     episodesRepository: EpisodesRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-    val state = combine(
-        episodesRepository.getFavoritesFlow(),
-        episodesRepository.getCurrentEpisode(),
-        settings.getPlayingStateFlow(),
-    ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
-        val currentlyPlaying =
-            if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                currentlyPlayingEpisode
-            } else {
-                null
-            }
-        FavoritesViewState(subscribedEpisodes, currentlyPlaying?.id, playingState)
-    }.stateIn(
-        viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = FavoritesViewState(),
-    )
+    val state =
+        combine(
+            episodesRepository.getFavoritesFlow(),
+            episodesRepository.getCurrentEpisode(),
+            settings.getPlayingStateFlow(),
+        ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+            val currentlyPlaying =
+                if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                    currentlyPlayingEpisode
+                } else {
+                    null
+                }
+            FavoritesViewState(subscribedEpisodes, currentlyPlaying?.id, playingState)
+        }.stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = FavoritesViewState(),
+        )
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
@@ -10,10 +10,12 @@ import com.ramitsuri.podcasts.repositories.PodcastsRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
 import com.ramitsuri.podcasts.utils.LogHelper
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -25,19 +27,44 @@ class HomeViewModel internal constructor(
     private val podcastsRepository: PodcastsRepository,
 ) : ViewModel(), EpisodeController by episodeController {
     private val _state = MutableStateFlow(HomeViewState())
-    val state = _state.asStateFlow()
+    private val _page = MutableStateFlow(1L)
+    private var availableEpisodeCount: Long = 0
 
-    private var updatePodcastsAndEpisodesJob: Job? = null
+    val state = _page
+        .flatMapLatest { page ->
+            combine(
+                podcastsAndEpisodesRepository.getSubscribedPodcastsFlow(),
+                podcastsAndEpisodesRepository.getSubscribedFlow(page),
+                episodesRepository.getCurrentEpisode(),
+                settings.getPlayingStateFlow(),
+            ) { subscribedPodcasts, subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+                val currentlyPlaying =
+                    if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                        currentlyPlayingEpisode
+                    } else {
+                        null
+                    }
+                Data(subscribedPodcasts, subscribedEpisodes, currentlyPlaying, playingState)
+            }
+        }
+        .map { (subscribedPodcasts, subscribedEpisodes, currentlyPlayingEpisode, playingState) ->
+            LogHelper.d(TAG, "Total episodes being shown: ${subscribedEpisodes.size}")
+            HomeViewState(
+                subscribedPodcasts = subscribedPodcasts,
+                episodes = subscribedEpisodes,
+                currentlyPlayingEpisodeId = currentlyPlayingEpisode?.id,
+                currentlyPlayingEpisodeState = playingState,
+            )
+        }
+        .stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = HomeViewState(),
+        )
 
     init {
         viewModelScope.launch {
-            launch {
-                _state.update {
-                    val episodeCount = podcastsAndEpisodesRepository.getEpisodeCountForSubscribedPodcasts()
-                    it.copy(availableEpisodeCount = episodeCount)
-                }
-            }
-            updatePodcastsAndEpisodes()
+            availableEpisodeCount = podcastsAndEpisodesRepository.getEpisodeCountForSubscribedPodcasts()
         }
     }
 
@@ -51,47 +78,13 @@ class HomeViewModel internal constructor(
 
     fun onNextPageRequested() {
         val state = _state.value
-        val availableEpisodeCount = state.availableEpisodeCount
         if (state.episodes.size.toLong() == availableEpisodeCount) {
             LogHelper.v(TAG, "Episodes next page requested but no more episodes")
             return
         }
-        val newPage = state.page + 1
+        val newPage = _page.value + 1
         LogHelper.d(TAG, "Episodes next page requested: $newPage")
-        _state.update { it.copy(page = newPage) }
-        updatePodcastsAndEpisodes()
-    }
-
-    private fun updatePodcastsAndEpisodes() {
-        val page = _state.value.page
-        updatePodcastsAndEpisodesJob?.cancel()
-        updatePodcastsAndEpisodesJob =
-            viewModelScope.launch {
-                combine(
-                    podcastsAndEpisodesRepository.getSubscribedPodcastsFlow(),
-                    podcastsAndEpisodesRepository.getSubscribedFlow(page),
-                    episodesRepository.getCurrentEpisode(),
-                    settings.getPlayingStateFlow(),
-                ) { subscribedPodcasts, subscribedEpisodes, currentlyPlayingEpisode, playingState ->
-                    val currentlyPlaying =
-                        if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                            currentlyPlayingEpisode
-                        } else {
-                            null
-                        }
-                    Data(subscribedPodcasts, subscribedEpisodes, currentlyPlaying, playingState)
-                }.collect { (subscribedPodcasts, subscribedEpisodes, currentlyPlayingEpisode, playingState) ->
-                    LogHelper.d(TAG, "Total episodes being shown: ${subscribedEpisodes.size}")
-                    _state.update {
-                        it.copy(
-                            subscribedPodcasts = subscribedPodcasts,
-                            episodes = subscribedEpisodes,
-                            currentlyPlayingEpisodeId = currentlyPlayingEpisode?.id,
-                            currentlyPlayingEpisodeState = playingState,
-                        )
-                    }
-                }
-            }
+        _page.update { newPage }
     }
 
     private data class Data(

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
@@ -23,7 +23,6 @@ class HomeViewModel internal constructor(
     private val settings: Settings,
     private val podcastsRepository: PodcastsRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-    private val _state = MutableStateFlow(HomeViewState())
     private val _page = MutableStateFlow(1L)
     private var availableEpisodeCount: Long = 0
 
@@ -63,7 +62,7 @@ class HomeViewModel internal constructor(
     }
 
     fun markPodcastHasNewSeen(podcastId: Long): Boolean {
-        val hadNewEpisodes = _state.value.subscribedPodcasts.firstOrNull { it.id == podcastId }?.hasNewEpisodes == true
+        val hadNewEpisodes = state.value.subscribedPodcasts.firstOrNull { it.id == podcastId }?.hasNewEpisodes == true
         viewModelScope.launch {
             podcastsRepository.updateHasNewEpisodes(podcastId, false)
         }
@@ -71,8 +70,7 @@ class HomeViewModel internal constructor(
     }
 
     fun onNextPageRequested() {
-        val state = _state.value
-        if (state.episodes.size.toLong() == availableEpisodeCount) {
+        if (state.value.episodes.size.toLong() == availableEpisodeCount) {
             LogHelper.v(TAG, "Episodes next page requested but no more episodes")
             return
         }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
@@ -1,8 +1,6 @@
 package com.ramitsuri.podcasts.viewmodel
 
-import com.ramitsuri.podcasts.model.Episode
 import com.ramitsuri.podcasts.model.PlayingState
-import com.ramitsuri.podcasts.model.Podcast
 import com.ramitsuri.podcasts.model.ui.HomeViewState
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.repositories.PodcastsAndEpisodesRepository
@@ -14,7 +12,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -38,23 +35,20 @@ class HomeViewModel internal constructor(
                 episodesRepository.getCurrentEpisode(),
                 settings.getPlayingStateFlow(),
             ) { subscribedPodcasts, subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+                LogHelper.d(TAG, "Total episodes being shown: ${subscribedEpisodes.size}")
                 val currentlyPlaying =
                     if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
                         currentlyPlayingEpisode
                     } else {
                         null
                     }
-                Data(subscribedPodcasts, subscribedEpisodes, currentlyPlaying, playingState)
+                HomeViewState(
+                    subscribedPodcasts = subscribedPodcasts,
+                    episodes = subscribedEpisodes,
+                    currentlyPlayingEpisodeId = currentlyPlaying?.id,
+                    currentlyPlayingEpisodeState = playingState,
+                )
             }
-        }
-        .map { (subscribedPodcasts, subscribedEpisodes, currentlyPlayingEpisode, playingState) ->
-            LogHelper.d(TAG, "Total episodes being shown: ${subscribedEpisodes.size}")
-            HomeViewState(
-                subscribedPodcasts = subscribedPodcasts,
-                episodes = subscribedEpisodes,
-                currentlyPlayingEpisodeId = currentlyPlayingEpisode?.id,
-                currentlyPlayingEpisodeState = playingState,
-            )
         }
         .stateIn(
             viewModelScope,
@@ -86,13 +80,6 @@ class HomeViewModel internal constructor(
         LogHelper.d(TAG, "Episodes next page requested: $newPage")
         _page.update { newPage }
     }
-
-    private data class Data(
-        val podcasts: List<Podcast>,
-        val episodes: List<Episode>,
-        val currentEpisode: Episode?,
-        val playingState: PlayingState,
-    )
 
     companion object {
         private const val TAG = "HomeViewModel"

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
@@ -23,10 +23,10 @@ class HomeViewModel internal constructor(
     private val settings: Settings,
     private val podcastsRepository: PodcastsRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-    private val _page = MutableStateFlow(1L)
+    private val page = MutableStateFlow(1L)
     private var availableEpisodeCount: Long = 0
 
-    val state = _page
+    val state = page
         .flatMapLatest { page ->
             combine(
                 podcastsAndEpisodesRepository.getSubscribedPodcastsFlow(),
@@ -74,9 +74,9 @@ class HomeViewModel internal constructor(
             LogHelper.v(TAG, "Episodes next page requested but no more episodes")
             return
         }
-        val newPage = _page.value + 1
+        val newPage = page.value + 1
         LogHelper.d(TAG, "Episodes next page requested: $newPage")
-        _page.update { newPage }
+        page.update { newPage }
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/HomeViewModel.kt
@@ -26,34 +26,35 @@ class HomeViewModel internal constructor(
     private val page = MutableStateFlow(1L)
     private var availableEpisodeCount: Long = 0
 
-    val state = page
-        .flatMapLatest { page ->
-            combine(
-                podcastsAndEpisodesRepository.getSubscribedPodcastsFlow(),
-                podcastsAndEpisodesRepository.getSubscribedFlow(page),
-                episodesRepository.getCurrentEpisode(),
-                settings.getPlayingStateFlow(),
-            ) { subscribedPodcasts, subscribedEpisodes, currentlyPlayingEpisode, playingState ->
-                LogHelper.d(TAG, "Total episodes being shown: ${subscribedEpisodes.size}")
-                val currentlyPlaying =
-                    if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                        currentlyPlayingEpisode
-                    } else {
-                        null
-                    }
-                HomeViewState(
-                    subscribedPodcasts = subscribedPodcasts,
-                    episodes = subscribedEpisodes,
-                    currentlyPlayingEpisodeId = currentlyPlaying?.id,
-                    currentlyPlayingEpisodeState = playingState,
-                )
+    val state =
+        page
+            .flatMapLatest { page ->
+                combine(
+                    podcastsAndEpisodesRepository.getSubscribedPodcastsFlow(),
+                    podcastsAndEpisodesRepository.getSubscribedFlow(page),
+                    episodesRepository.getCurrentEpisode(),
+                    settings.getPlayingStateFlow(),
+                ) { subscribedPodcasts, subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+                    LogHelper.d(TAG, "Total episodes being shown: ${subscribedEpisodes.size}")
+                    val currentlyPlaying =
+                        if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                            currentlyPlayingEpisode
+                        } else {
+                            null
+                        }
+                    HomeViewState(
+                        subscribedPodcasts = subscribedPodcasts,
+                        episodes = subscribedEpisodes,
+                        currentlyPlayingEpisodeId = currentlyPlaying?.id,
+                        currentlyPlayingEpisodeState = playingState,
+                    )
+                }
             }
-        }
-        .stateIn(
-            viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = HomeViewState(),
-        )
+            .stateIn(
+                viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = HomeViewState(),
+            )
 
     init {
         viewModelScope.launch {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -1,7 +1,6 @@
 package com.ramitsuri.podcasts.viewmodel
 
 import com.ramitsuri.podcasts.model.PlayingState
-import com.ramitsuri.podcasts.model.ui.HomeViewState
 import com.ramitsuri.podcasts.model.ui.QueueViewState
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -1,14 +1,14 @@
 package com.ramitsuri.podcasts.viewmodel
 
 import com.ramitsuri.podcasts.model.PlayingState
+import com.ramitsuri.podcasts.model.ui.HomeViewState
 import com.ramitsuri.podcasts.model.ui.QueueViewState
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class QueueViewModel internal constructor(
@@ -16,42 +16,36 @@ class QueueViewModel internal constructor(
     settings: Settings,
     private val episodesRepository: EpisodesRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-    private val _state = MutableStateFlow(QueueViewState())
-    val state = _state.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            combine(
-                episodesRepository.getQueueFlow(),
-                episodesRepository.getCurrentEpisode(),
-                settings.getPlayingStateFlow(),
-            ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
-                val currentlyPlaying =
-                    if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                        currentlyPlayingEpisode
-                    } else {
-                        null
-                    }
-                Triple(subscribedEpisodes, currentlyPlaying, playingState)
-            }.collect { (subscribedEpisodes, currentlyPlayingEpisode, playingState) ->
-                _state.update {
-                    it.copy(
-                        episodes = subscribedEpisodes,
-                        currentlyPlayingEpisodeId = currentlyPlayingEpisode?.id,
-                        currentlyPlayingEpisodeState = playingState,
-                    )
-                }
+    val state = combine(
+        episodesRepository.getQueueFlow(),
+        episodesRepository.getCurrentEpisode(),
+        settings.getPlayingStateFlow(),
+    ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+        val currentlyPlaying =
+            if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                currentlyPlayingEpisode
+            } else {
+                null
             }
-        }
+        QueueViewState(
+            episodes = subscribedEpisodes,
+            currentlyPlayingEpisodeId = currentlyPlaying?.id,
+            currentlyPlayingEpisodeState = playingState,
+        )
     }
+        .stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = QueueViewState(),
+        )
 
     fun onEpisodeRearrangementRequested(
         position1: Int,
         position2: Int,
     ) {
         viewModelScope.launch {
-            val currentlyAtPosition1 = _state.value.episodes.getOrNull(position1)
-            val currentlyAtPosition2 = _state.value.episodes.getOrNull(position2)
+            val currentlyAtPosition1 = state.value.episodes.getOrNull(position1)
+            val currentlyAtPosition2 = state.value.episodes.getOrNull(position2)
             if (currentlyAtPosition1 != null && currentlyAtPosition2 != null) {
                 episodesRepository.updateQueuePositions(
                     currentlyAtPosition1.id,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -15,28 +15,29 @@ class QueueViewModel internal constructor(
     settings: Settings,
     private val episodesRepository: EpisodesRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-    val state = combine(
-        episodesRepository.getQueueFlow(),
-        episodesRepository.getCurrentEpisode(),
-        settings.getPlayingStateFlow(),
-    ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
-        val currentlyPlaying =
-            if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
-                currentlyPlayingEpisode
-            } else {
-                null
-            }
-        QueueViewState(
-            episodes = subscribedEpisodes,
-            currentlyPlayingEpisodeId = currentlyPlaying?.id,
-            currentlyPlayingEpisodeState = playingState,
-        )
-    }
-        .stateIn(
-            viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = QueueViewState(),
-        )
+    val state =
+        combine(
+            episodesRepository.getQueueFlow(),
+            episodesRepository.getCurrentEpisode(),
+            settings.getPlayingStateFlow(),
+        ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+            val currentlyPlaying =
+                if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
+                    currentlyPlayingEpisode
+                } else {
+                    null
+                }
+            QueueViewState(
+                episodes = subscribedEpisodes,
+                currentlyPlayingEpisodeId = currentlyPlaying?.id,
+                currentlyPlayingEpisodeState = playingState,
+            )
+        }
+            .stateIn(
+                viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = QueueViewState(),
+            )
 
     fun onEpisodeRearrangementRequested(
         position1: Int,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
@@ -19,25 +19,26 @@ class SettingsViewModel internal constructor(
 ) : ViewModel() {
     private val fetching = MutableStateFlow(false)
 
-    val state = combine(
-        settings.autoPlayNextInQueue(),
-        settings.getLastEpisodeFetchTime(),
-        settings.getRemoveCompletedEpisodesAfter(),
-        settings.getRemoveUnfinishedEpisodesAfter(),
-        fetching,
-    ) { autoPlayNextInQueue, lastFetchTime, removeCompletedAfter, removeUnfinishedAfter, fetching ->
-        SettingsViewState(
-            autoPlayNextInQueue = autoPlayNextInQueue,
-            lastFetchTime = lastFetchTime,
-            removeCompletedAfter = removeCompletedAfter,
-            removeUnfinishedAfter = removeUnfinishedAfter,
-            fetching = fetching,
+    val state =
+        combine(
+            settings.autoPlayNextInQueue(),
+            settings.getLastEpisodeFetchTime(),
+            settings.getRemoveCompletedEpisodesAfter(),
+            settings.getRemoveUnfinishedEpisodesAfter(),
+            fetching,
+        ) { autoPlayNextInQueue, lastFetchTime, removeCompletedAfter, removeUnfinishedAfter, fetching ->
+            SettingsViewState(
+                autoPlayNextInQueue = autoPlayNextInQueue,
+                lastFetchTime = lastFetchTime,
+                removeCompletedAfter = removeCompletedAfter,
+                removeUnfinishedAfter = removeUnfinishedAfter,
+                fetching = fetching,
+            )
+        }.stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = SettingsViewState(),
         )
-    }.stateIn(
-        viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = SettingsViewState(),
-    )
 
     fun toggleAutoPlayNextInQueue() {
         val currentAutoPlayNextInQueue = state.value.autoPlayNextInQueue

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
@@ -17,14 +17,14 @@ class SettingsViewModel internal constructor(
     private val episodeFetcher: EpisodeFetcher,
     private val longLivingScope: CoroutineScope,
 ) : ViewModel() {
-    private val _fetching = MutableStateFlow(false)
+    private val fetching = MutableStateFlow(false)
 
     val state = combine(
         settings.autoPlayNextInQueue(),
         settings.getLastEpisodeFetchTime(),
         settings.getRemoveCompletedEpisodesAfter(),
         settings.getRemoveUnfinishedEpisodesAfter(),
-        _fetching,
+        fetching,
     ) { autoPlayNextInQueue, lastFetchTime, removeCompletedAfter, removeUnfinishedAfter, fetching ->
         SettingsViewState(
             autoPlayNextInQueue = autoPlayNextInQueue,
@@ -48,9 +48,9 @@ class SettingsViewModel internal constructor(
 
     fun fetch() {
         longLivingScope.launch {
-            _fetching.update { true }
+            fetching.update { true }
             episodeFetcher.fetchPodcastsIfNecessary(forced = true, downloaderTasksAllowed = true)
-            _fetching.update { false }
+            fetching.update { false }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SettingsViewModel.kt
@@ -6,44 +6,41 @@ import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeFetcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Instant
 
 class SettingsViewModel internal constructor(
     private val settings: Settings,
     private val episodeFetcher: EpisodeFetcher,
     private val longLivingScope: CoroutineScope,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(SettingsViewState())
-    val state = _state.asStateFlow()
+    private val _fetching = MutableStateFlow(false)
 
-    init {
-        viewModelScope.launch {
-            combine(
-                settings.autoPlayNextInQueue(),
-                settings.getLastEpisodeFetchTime(),
-                settings.getRemoveCompletedEpisodesAfter(),
-                settings.getRemoveUnfinishedEpisodesAfter(),
-            ) { autoPlayNextInQueue, lastFetchTime, removeCompletedAfter, removeUnfinishedAfter ->
-                Data(autoPlayNextInQueue, lastFetchTime, removeCompletedAfter, removeUnfinishedAfter)
-            }.collect { (autoPlayNextInQueue, lastFetchTime, removeCompletedAfter, removeUnfinishedAfter) ->
-                _state.update {
-                    it.copy(
-                        autoPlayNextInQueue = autoPlayNextInQueue,
-                        lastFetchTime = lastFetchTime,
-                        removeCompletedAfter = removeCompletedAfter,
-                        removeUnfinishedAfter = removeUnfinishedAfter,
-                    )
-                }
-            }
-        }
-    }
+    val state = combine(
+        settings.autoPlayNextInQueue(),
+        settings.getLastEpisodeFetchTime(),
+        settings.getRemoveCompletedEpisodesAfter(),
+        settings.getRemoveUnfinishedEpisodesAfter(),
+        _fetching,
+    ) { autoPlayNextInQueue, lastFetchTime, removeCompletedAfter, removeUnfinishedAfter, fetching ->
+        SettingsViewState(
+            autoPlayNextInQueue = autoPlayNextInQueue,
+            lastFetchTime = lastFetchTime,
+            removeCompletedAfter = removeCompletedAfter,
+            removeUnfinishedAfter = removeUnfinishedAfter,
+            fetching = fetching,
+        )
+    }.stateIn(
+        viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = SettingsViewState(),
+    )
 
     fun toggleAutoPlayNextInQueue() {
-        val currentAutoPlayNextInQueue = _state.value.autoPlayNextInQueue
+        val currentAutoPlayNextInQueue = state.value.autoPlayNextInQueue
         longLivingScope.launch {
             settings.setAutoPlayNextInQueue(autoPlayNextInQueue = !currentAutoPlayNextInQueue)
         }
@@ -51,9 +48,9 @@ class SettingsViewModel internal constructor(
 
     fun fetch() {
         longLivingScope.launch {
-            _state.update { it.copy(fetching = true) }
+            _fetching.update { true }
             episodeFetcher.fetchPodcastsIfNecessary(forced = true, downloaderTasksAllowed = true)
-            _state.update { it.copy(fetching = false) }
+            _fetching.update { false }
         }
     }
 
@@ -68,11 +65,4 @@ class SettingsViewModel internal constructor(
             settings.setRemoveUnfinishedEpisodesAfter(removeUnfinishedAfter)
         }
     }
-
-    private data class Data(
-        val autoPlayNextInQueue: Boolean,
-        val lastFetchTime: Instant,
-        val removeCompletedAfter: RemoveDownloadsAfter,
-        val removeUnfinishedAfter: RemoveDownloadsAfter,
-    )
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SubscriptionsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SubscriptionsViewModel.kt
@@ -9,13 +9,14 @@ import kotlinx.coroutines.flow.stateIn
 class SubscriptionsViewModel(
     podcastsAndEpisodesRepository: PodcastsAndEpisodesRepository,
 ) : ViewModel() {
-    val state = podcastsAndEpisodesRepository
-        .getSubscribedPodcastsFlow()
-        .map { subscribedPodcasts ->
-            SubscriptionsViewState(subscribedPodcasts = subscribedPodcasts.sortedBy { podcast -> podcast.title })
-        }.stateIn(
-            viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = SubscriptionsViewState(),
-        )
+    val state =
+        podcastsAndEpisodesRepository
+            .getSubscribedPodcastsFlow()
+            .map { subscribedPodcasts ->
+                SubscriptionsViewState(subscribedPodcasts = subscribedPodcasts.sortedBy { podcast -> podcast.title })
+            }.stateIn(
+                viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = SubscriptionsViewState(),
+            )
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SubscriptionsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/SubscriptionsViewModel.kt
@@ -2,24 +2,20 @@ package com.ramitsuri.podcasts.viewmodel
 
 import com.ramitsuri.podcasts.model.ui.SubscriptionsViewState
 import com.ramitsuri.podcasts.repositories.PodcastsAndEpisodesRepository
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 class SubscriptionsViewModel(
     podcastsAndEpisodesRepository: PodcastsAndEpisodesRepository,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(SubscriptionsViewState())
-    val state = _state.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            podcastsAndEpisodesRepository.getSubscribedPodcastsFlow().collect { subscribedPodcasts ->
-                _state.update {
-                    it.copy(subscribedPodcasts = subscribedPodcasts.sortedBy { podcast -> podcast.title })
-                }
-            }
-        }
-    }
+    val state = podcastsAndEpisodesRepository
+        .getSubscribedPodcastsFlow()
+        .map { subscribedPodcasts ->
+            SubscriptionsViewState(subscribedPodcasts = subscribedPodcasts.sortedBy { podcast -> podcast.title })
+        }.stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = SubscriptionsViewState(),
+        )
 }


### PR DESCRIPTION
Simplified state generation in VMs by not collecting flows all the time, rather
using the recommended `stateIn` operator. 

There are some VMs that haven't been refactored 
- SearchViewModel. Because state isn't always being collected here, only on demand
- PodcastDetailsViewModel. Because page calculation here is more complex
- ImportSubscriptionsViewModel. Because here also state isn't always collected 
but only on demand
- PlayerViewModel. This is also complex. 