### PR TITLE
Hide episode controls in History

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/history/EpisodeHistoryScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/history/EpisodeHistoryScreen.kt
@@ -2,6 +2,7 @@ package com.ramitsuri.podcasts.android.ui.history
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -24,16 +26,21 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.ramitsuri.podcasts.android.R
 import com.ramitsuri.podcasts.android.ui.components.ColoredHorizontalDivider
-import com.ramitsuri.podcasts.android.ui.components.EpisodeItem
+import com.ramitsuri.podcasts.android.ui.components.EpisodeControls
+import com.ramitsuri.podcasts.android.ui.components.Image
 import com.ramitsuri.podcasts.android.ui.components.TopAppBar
 import com.ramitsuri.podcasts.android.utils.dateFormatted
+import com.ramitsuri.podcasts.android.utils.friendlyPublishDate
 import com.ramitsuri.podcasts.model.Episode
 import com.ramitsuri.podcasts.model.PlayingState
 import com.ramitsuri.podcasts.model.ui.EpisodeHistoryViewState
@@ -105,6 +112,85 @@ fun EpisodeHistoryScreen(
         if (state.episodesByDate.isEmpty()) {
             EpisodeHistoryEmpty()
         }
+    }
+}
+
+@Composable
+private fun EpisodeItem(
+    episode: Episode,
+    playingState: PlayingState,
+    onClicked: () -> Unit,
+    onPlayClicked: () -> Unit,
+    onPauseClicked: () -> Unit,
+    onAddToQueueClicked: () -> Unit,
+    onRemoveFromQueueClicked: () -> Unit,
+    onDownloadClicked: () -> Unit,
+    onRemoveDownloadClicked: () -> Unit,
+    onCancelDownloadClicked: () -> Unit,
+    onPlayedClicked: () -> Unit,
+    onNotPlayedClicked: () -> Unit,
+    onFavoriteClicked: () -> Unit,
+    onNotFavoriteClicked: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .clickable(onClick = onClicked)
+                .padding(top = 12.dp, bottom = 4.dp)
+                .padding(horizontal = 16.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Image(
+                url = episode.podcastImageUrl,
+                contentDescription = episode.title,
+                modifier =
+                    Modifier
+                        .clip(MaterialTheme.shapes.extraSmall)
+                        .size(40.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Column {
+                Text(
+                    style = MaterialTheme.typography.bodySmall.copy(fontSize = 13.sp),
+                    text = episode.podcastName,
+                )
+                val datePublished = episode.datePublishedInstant
+                if (datePublished != null) {
+                    Text(
+                        style = MaterialTheme.typography.bodySmall,
+                        text = friendlyPublishDate(publishedDateTime = datePublished),
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            style = MaterialTheme.typography.bodyLarge,
+            text = episode.title,
+            fontWeight = FontWeight.Medium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        EpisodeControls(
+            episode = episode,
+            showDownloadButton = false,
+            showMenuButton = false,
+            showQueueButton = false,
+            playingState = playingState,
+            onPlayClicked = onPlayClicked,
+            onPauseClicked = onPauseClicked,
+            onAddToQueueClicked = onAddToQueueClicked,
+            onRemoveFromQueueClicked = onRemoveFromQueueClicked,
+            onDownloadClicked = onDownloadClicked,
+            onRemoveDownloadClicked = onRemoveDownloadClicked,
+            onCancelDownloadClicked = onCancelDownloadClicked,
+            onPlayedClicked = onPlayedClicked,
+            onNotPlayedClicked = onNotPlayedClicked,
+            onFavoriteClicked = onFavoriteClicked,
+            onNotFavoriteClicked = onNotFavoriteClicked,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 


### PR DESCRIPTION
Hiding because they don't work other than play pause. Would need to
collect all episodes I believe because the data that is changed when
adding to/removing from queue, is in a different table.
