### PR TITLE
Fix queue rearragement animation

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
@@ -16,7 +16,7 @@ class QueueRearrangementHelper(
     private val _queuePositions = MutableStateFlow<Map<String, Int>>(mapOf())
     val queuePositions = _queuePositions.asStateFlow()
 
-    private val queueRearrangementChannel = Channel<Positions>() // Episode id and new queue position
+    private val queueRearrangementChannel = Channel<Positions>()
 
     suspend fun updateQueuePositions(
         id1: String,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 
 class QueueRearrangementHelper(
     scope: CoroutineScope,
-    repo: EpisodesRepository
+    repo: EpisodesRepository,
 ) {
     private val _queuePositions = MutableStateFlow<Map<String, Int>>(mapOf())
     val queuePositions = _queuePositions.asStateFlow()

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
@@ -1,0 +1,52 @@
+package com.ramitsuri.podcasts.utils
+
+import com.ramitsuri.podcasts.repositories.EpisodesRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class QueueRearrangementHelper(
+    private val scope: CoroutineScope,
+    repo: EpisodesRepository
+) {
+    private val _queuePositions = MutableStateFlow<Map<String, Int>>(mapOf())
+    val queuePositions = _queuePositions.asStateFlow()
+
+    private val queueRearrangementChannel = Channel<Positions>() // Episode id and new queue position
+
+    fun updateQueuePositions(
+        id1: String,
+        position1: Int,
+        id2: String,
+        position2: Int,
+    ) {
+        _queuePositions.update {
+            it.toMutableMap().apply {
+                put(id1, position1)
+                put(id2, position2)
+            }
+        }
+        scope.launch {
+            queueRearrangementChannel.send(Positions(id1, position1, id2, position2))
+        }
+    }
+
+    init {
+        scope.launch {
+            queueRearrangementChannel.consumeEach { positions ->
+                repo.updateQueuePositions(positions.id1, positions.position1, positions.id2, positions.position2)
+            }
+        }
+    }
+
+    private data class Positions(
+        val id1: String,
+        val position1: Int,
+        val id2: String,
+        val position2: Int,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class QueueRearrangementHelper(
-    private val scope: CoroutineScope,
+    scope: CoroutineScope,
     repo: EpisodesRepository
 ) {
     private val _queuePositions = MutableStateFlow<Map<String, Int>>(mapOf())
@@ -18,7 +18,7 @@ class QueueRearrangementHelper(
 
     private val queueRearrangementChannel = Channel<Positions>() // Episode id and new queue position
 
-    fun updateQueuePositions(
+    suspend fun updateQueuePositions(
         id1: String,
         position1: Int,
         id2: String,
@@ -30,9 +30,7 @@ class QueueRearrangementHelper(
                 put(id2, position2)
             }
         }
-        scope.launch {
-            queueRearrangementChannel.send(Positions(id1, position1, id2, position2))
-        }
+        queueRearrangementChannel.send(Positions(id1, position1, id2, position2))
     }
 
     init {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -16,7 +16,6 @@ class QueueViewModel internal constructor(
     settings: Settings,
     episodesRepository: EpisodesRepository,
 ) : ViewModel(), EpisodeController by episodeController {
-
     private val queueRearrangementHelper = QueueRearrangementHelper(viewModelScope, episodesRepository)
 
     val state =
@@ -32,9 +31,10 @@ class QueueViewModel internal constructor(
                 } else {
                     null
                 }
-            val episodes = subscribedEpisodes.map {
-                it.copy(queuePosition = queuePositions[it.id] ?: it.queuePosition)
-            }.sortedBy { it.queuePosition }
+            val episodes =
+                subscribedEpisodes.map {
+                    it.copy(queuePosition = queuePositions[it.id] ?: it.queuePosition)
+                }.sortedBy { it.queuePosition }
             QueueViewState(
                 episodes = episodes,
                 currentlyPlayingEpisodeId = currentlyPlaying?.id,

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -57,15 +57,17 @@ class QueueViewModel internal constructor(
         position1: Int,
         position2: Int,
     ) {
-        val currentlyAtPosition1 = _state.value.episodes.getOrNull(position1)
-        val currentlyAtPosition2 = _state.value.episodes.getOrNull(position2)
-        if (currentlyAtPosition1 != null && currentlyAtPosition2 != null) {
-            queueRearrangementHelper.updateQueuePositions(
-                currentlyAtPosition1.id,
-                currentlyAtPosition2.queuePosition,
-                currentlyAtPosition2.id,
-                currentlyAtPosition1.queuePosition,
-            )
+        viewModelScope.launch {
+            val currentlyAtPosition1 = _state.value.episodes.getOrNull(position1)
+            val currentlyAtPosition2 = _state.value.episodes.getOrNull(position2)
+            if (currentlyAtPosition1 != null && currentlyAtPosition2 != null) {
+                queueRearrangementHelper.updateQueuePositions(
+                    currentlyAtPosition1.id,
+                    currentlyAtPosition2.queuePosition,
+                    currentlyAtPosition2.id,
+                    currentlyAtPosition1.queuePosition,
+                )
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -1,10 +1,12 @@
 package com.ramitsuri.podcasts.viewmodel
 
+import com.ramitsuri.podcasts.model.Episode
 import com.ramitsuri.podcasts.model.PlayingState
 import com.ramitsuri.podcasts.model.ui.QueueViewState
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
+import com.ramitsuri.podcasts.utils.QueueRearrangementHelper
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -19,24 +21,30 @@ class QueueViewModel internal constructor(
     private val _state = MutableStateFlow(QueueViewState())
     val state = _state.asStateFlow()
 
+    private val queueRearrangementHelper = QueueRearrangementHelper(viewModelScope, episodesRepository)
+
     init {
         viewModelScope.launch {
             combine(
+                queueRearrangementHelper.queuePositions,
                 episodesRepository.getQueueFlow(),
                 episodesRepository.getCurrentEpisode(),
                 settings.getPlayingStateFlow(),
-            ) { subscribedEpisodes, currentlyPlayingEpisode, playingState ->
+            ) { queuePositions, subscribedEpisodes, currentlyPlayingEpisode, playingState ->
                 val currentlyPlaying =
                     if (playingState == PlayingState.PLAYING || playingState == PlayingState.LOADING) {
                         currentlyPlayingEpisode
                     } else {
                         null
                     }
-                Triple(subscribedEpisodes, currentlyPlaying, playingState)
-            }.collect { (subscribedEpisodes, currentlyPlayingEpisode, playingState) ->
-                _state.update {
-                    it.copy(
-                        episodes = subscribedEpisodes,
+                Data(queuePositions, subscribedEpisodes, currentlyPlaying, playingState)
+            }.collect { (queuePositions, subscribedEpisodes, currentlyPlayingEpisode, playingState) ->
+                val episodes = subscribedEpisodes.map {
+                    it.copy(queuePosition = queuePositions[it.id] ?: it.queuePosition)
+                }.sortedBy { it.queuePosition }
+                _state.update { viewState ->
+                    viewState.copy(
+                        episodes = episodes,
                         currentlyPlayingEpisodeId = currentlyPlayingEpisode?.id,
                         currentlyPlayingEpisodeState = playingState,
                     )
@@ -49,17 +57,22 @@ class QueueViewModel internal constructor(
         position1: Int,
         position2: Int,
     ) {
-        viewModelScope.launch {
-            val currentlyAtPosition1 = _state.value.episodes.getOrNull(position1)
-            val currentlyAtPosition2 = _state.value.episodes.getOrNull(position2)
-            if (currentlyAtPosition1 != null && currentlyAtPosition2 != null) {
-                episodesRepository.updateQueuePositions(
-                    currentlyAtPosition1.id,
-                    currentlyAtPosition2.queuePosition,
-                    currentlyAtPosition2.id,
-                    currentlyAtPosition1.queuePosition,
-                )
-            }
+        val currentlyAtPosition1 = _state.value.episodes.getOrNull(position1)
+        val currentlyAtPosition2 = _state.value.episodes.getOrNull(position2)
+        if (currentlyAtPosition1 != null && currentlyAtPosition2 != null) {
+            queueRearrangementHelper.updateQueuePositions(
+                currentlyAtPosition1.id,
+                currentlyAtPosition2.queuePosition,
+                currentlyAtPosition2.id,
+                currentlyAtPosition1.queuePosition,
+            )
         }
     }
+
+    private data class Data(
+        val queuePosition: Map<String, Int>,
+        val subscribedEpisodes: List<Episode>,
+        val currentlyPlaying: Episode?,
+        val playingState: PlayingState
+    )
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -1,6 +1,5 @@
 package com.ramitsuri.podcasts.viewmodel
 
-import com.ramitsuri.podcasts.model.Episode
 import com.ramitsuri.podcasts.model.PlayingState
 import com.ramitsuri.podcasts.model.ui.QueueViewState
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
@@ -65,11 +64,4 @@ class QueueViewModel internal constructor(
             }
         }
     }
-
-    private data class Data(
-        val queuePosition: Map<String, Int>,
-        val subscribedEpisodes: List<Episode>,
-        val currentlyPlaying: Episode?,
-        val playingState: PlayingState
-    )
 }


### PR DESCRIPTION
Was able to verify that queue rearrangement needing to be saved to db is 
what was causing the laggy animating. Moved the episodes to an in memory 
list and then tried to rearrange them with that, but added 100ms delay with 
saving the list and was able to reproduce it. 

Fix was to have a queue to write changes from to database but then reflect
changes to UI right from in memory list. 