### PR TITLE
Fix auto play next from background

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/MainApplication.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.workmanager.dsl.worker
@@ -108,6 +109,11 @@ class MainApplication : Application(), ImageLoaderFactory, KoinComponent {
                 single<PlayerController> {
                     PlayerControllerImpl(
                         context = get<Application>(),
+                        coroutineScope = get<CoroutineScope>(),
+                        shouldAutoPlayNextInQueue = { settings.autoPlayNextInQueue().first() },
+                        getSleepTimer = { settings.getSleepTimerFlow().first() },
+                        getAppQueue = { get<EpisodesRepository>().getQueue() },
+                        getCurrentlyPlayingEpisode = { get<EpisodesRepository>().getCurrentEpisode().first() },
                     )
                 }
 

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PlayerControllerImpl.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PlayerControllerImpl.kt
@@ -61,30 +61,34 @@ class PlayerControllerImpl(
 
     override fun updateQueue() {
         updateQueueJob?.cancel()
-        updateQueueJob = coroutineScope.launch {
-            delay(300)
-            val currentEpisode = getCurrentlyPlayingEpisode()
-            val playerQueue = if (currentEpisode == null ||
-                currentEpisode.queuePosition == Episode.NOT_IN_QUEUE ||
-                shouldAutoPlayNextInQueue().not() ||
-                getSleepTimer() is SleepTimer.EndOfEpisode
-            ) {
-                emptyList()
-            } else {
-                getAppQueue().filter { it.queuePosition > currentEpisode.queuePosition }
+        updateQueueJob =
+            coroutineScope.launch {
+                delay(300)
+                val currentEpisode = getCurrentlyPlayingEpisode()
+                val playerQueue =
+                    if (currentEpisode == null ||
+                        currentEpisode.queuePosition == Episode.NOT_IN_QUEUE ||
+                        shouldAutoPlayNextInQueue().not() ||
+                        getSleepTimer() is SleepTimer.EndOfEpisode
+                    ) {
+                        emptyList()
+                    } else {
+                        getAppQueue().filter { it.queuePosition > currentEpisode.queuePosition }
+                    }
+                removeEverythingButCurrentEpisode()
+                addEpisodes(playerQueue)
+                logQueue()
             }
-            removeEverythingButCurrentEpisode()
-            addEpisodes(playerQueue)
-            logQueue()
-        }
     }
 
     override fun logQueue(): List<String> {
-        return (controller?.let {
-            (0 until it.mediaItemCount).map { index ->
-                "$index: ${it.getMediaItemAt(index).mediaMetadata.title.toString()}\n"
-            }
-        } ?: listOf("Controller is null")).also {
+        return (
+            controller?.let {
+                (0 until it.mediaItemCount).map { index ->
+                    "$index: ${it.getMediaItemAt(index).mediaMetadata.title}\n"
+                }
+            } ?: listOf("Controller is null")
+        ).also {
             LogHelper.d(TAG, "$it")
         }
     }

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PlayerControllerImpl.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/PlayerControllerImpl.kt
@@ -8,16 +8,28 @@ import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
 import com.ramitsuri.podcasts.model.Episode
+import com.ramitsuri.podcasts.model.ui.SleepTimer
 import com.ramitsuri.podcasts.player.PlayerController
 import com.ramitsuri.podcasts.utils.LogHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.time.Duration
 
 class PlayerControllerImpl(
     context: Context,
+    private val shouldAutoPlayNextInQueue: suspend () -> Boolean,
+    private val getSleepTimer: suspend () -> SleepTimer,
+    private val getAppQueue: suspend () -> List<Episode>,
+    private val getCurrentlyPlayingEpisode: suspend () -> Episode?,
+    private val coroutineScope: CoroutineScope,
 ) : PlayerController {
     private val appContext = context.applicationContext
     private var controller: MediaController? = null
     private var controllerFuture: ListenableFuture<MediaController>? = null
+
+    private var updateQueueJob: Job? = null
 
     override fun initializePlayer() {
         LogHelper.d(TAG, "Initialize player")
@@ -33,12 +45,67 @@ class PlayerControllerImpl(
     }
 
     override fun play(episode: Episode) {
+        if (controller?.currentMediaItem?.mediaId == episode.id) {
+            controller?.play()
+            updateQueue()
+            return
+        }
         controller?.setMediaItemForEpisode(episode)
         controller?.prepare()
         if (episode.progressInSeconds != 0) {
             controller?.seekTo(episode.progressInSeconds * 1000L)
         }
         controller?.play()
+        updateQueue()
+    }
+
+    override fun updateQueue() {
+        updateQueueJob?.cancel()
+        updateQueueJob = coroutineScope.launch {
+            delay(300)
+            val currentEpisode = getCurrentlyPlayingEpisode()
+            val playerQueue = if (currentEpisode == null ||
+                currentEpisode.queuePosition == Episode.NOT_IN_QUEUE ||
+                shouldAutoPlayNextInQueue().not() ||
+                getSleepTimer() is SleepTimer.EndOfEpisode
+            ) {
+                emptyList()
+            } else {
+                getAppQueue().filter { it.queuePosition > currentEpisode.queuePosition }
+            }
+            removeEverythingButCurrentEpisode()
+            addEpisodes(playerQueue)
+            logQueue()
+        }
+    }
+
+    override fun logQueue(): List<String> {
+        return (controller?.let {
+            (0 until it.mediaItemCount).map { index ->
+                "$index: ${it.getMediaItemAt(index).mediaMetadata.title.toString()}\n"
+            }
+        } ?: listOf("Controller is null")).also {
+            LogHelper.d(TAG, "$it")
+        }
+    }
+
+    private fun removeEverythingButCurrentEpisode() {
+        controller?.let {
+            val currentIndex = it.currentMediaItemIndex
+            for (index in (it.mediaItemCount - 1) downTo 0) {
+                if (index != currentIndex) {
+                    it.removeMediaItem(index)
+                }
+            }
+        }
+    }
+
+    private fun addEpisodes(episodes: List<Episode>) {
+        controller?.let {
+            for (queueEpisode in episodes) {
+                it.addMediaItem(queueEpisode.asMediaItem())
+            }
+        }
     }
 
     override fun pause() {
@@ -59,6 +126,14 @@ class PlayerControllerImpl(
         controllerFuture?.let {
             MediaController.releaseFuture(it)
         }
+    }
+
+    override fun playNext() {
+        controller?.seekToNextMediaItem()
+    }
+
+    override fun hasNext(): Boolean {
+        return controller?.hasNextMediaItem() == true
     }
 
     private fun MediaController.setMediaItemForEpisode(episode: Episode) {

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
@@ -159,10 +159,10 @@ fun NavGraph(
                 if (bottomSheetVisible) {
                     {
                         LifecycleStartEffect(Unit, LocalLifecycleOwner.current) {
-                            playerViewModel.initializePlayer()
+                            playerViewModel.viewStarted()
 
                             onStopOrDispose {
-                                // Do nothing
+                                playerViewModel.viewStopped()
                             }
                         }
                         PlayerScreen(

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerViewModel.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/player/PlayerViewModel.kt
@@ -256,24 +256,24 @@ class PlayerViewModel(
     }
 
     private fun startUpdatingQueue() {
-        updateQueueJob = longLivingScope.launch {
-            launch {
-                settings
-                    .autoPlayNextInQueue()
-                    .collect {
-                        playerController.updateQueue()
-                    }
-
+        updateQueueJob =
+            longLivingScope.launch {
+                launch {
+                    settings
+                        .autoPlayNextInQueue()
+                        .collect {
+                            playerController.updateQueue()
+                        }
+                }
+                launch {
+                    settings
+                        .getSleepTimerFlow()
+                        .filter { it is SleepTimer.EndOfEpisode }
+                        .collect {
+                            playerController.updateQueue()
+                        }
+                }
             }
-            launch {
-                settings
-                    .getSleepTimerFlow()
-                    .filter { it is SleepTimer.EndOfEpisode }
-                    .collect {
-                        playerController.updateQueue()
-                    }
-            }
-        }
     }
 
     private fun stopUpdatingQueue() {

--- a/shared/src/androidMain/kotlin/com/ramitsuri/podcasts/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/com/ramitsuri/podcasts/KoinAndroid.kt
@@ -3,6 +3,7 @@ package com.ramitsuri.podcasts
 import android.app.Application
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.ramitsuri.podcasts.player.PlayerController
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.repositories.PodcastsAndEpisodesRepository
 import com.ramitsuri.podcasts.repositories.PodcastsRepository
@@ -69,6 +70,7 @@ actual val platformModule =
                 episodeController = get<EpisodeController>(),
                 episodesRepository = get<EpisodesRepository>(),
                 settings = get<Settings>(),
+                playerController = get<PlayerController>(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/Koin.kt
@@ -158,7 +158,6 @@ private val coreModule =
                 episodesRepository = get(),
                 playerController = get(),
                 episodeDownloader = get(),
-                settings = get(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/player/PlayerController.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/player/PlayerController.kt
@@ -13,4 +13,12 @@ interface PlayerController {
     fun pause()
 
     fun seek(to: Duration)
+
+    fun updateQueue()
+
+    fun logQueue(): List<String>
+
+    fun playNext()
+
+    fun hasNext(): Boolean
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/EpisodeControllerImpl.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/EpisodeControllerImpl.kt
@@ -2,13 +2,9 @@ package com.ramitsuri.podcasts.utils
 
 import com.ramitsuri.podcasts.download.EpisodeDownloader
 import com.ramitsuri.podcasts.model.Episode
-import com.ramitsuri.podcasts.model.PlayingState
-import com.ramitsuri.podcasts.model.ui.SleepTimer
 import com.ramitsuri.podcasts.player.PlayerController
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
-import com.ramitsuri.podcasts.settings.Settings
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
@@ -17,7 +13,6 @@ internal class EpisodeControllerImpl(
     private val episodesRepository: EpisodesRepository,
     private val playerController: PlayerController,
     private val episodeDownloader: EpisodeDownloader,
-    private val settings: Settings,
 ) : EpisodeController {
     override fun onEpisodePlayClicked(episode: Episode) {
         longLivingScope.launch {
@@ -32,12 +27,14 @@ internal class EpisodeControllerImpl(
     override fun onEpisodeAddToQueueClicked(episode: Episode) {
         longLivingScope.launch {
             episodesRepository.addToQueue(episode.id)
+            playerController.updateQueue()
         }
     }
 
     override fun onEpisodeRemoveFromQueueClicked(episode: Episode) {
         longLivingScope.launch {
             episodesRepository.removeFromQueue(episode.id)
+            playerController.updateQueue()
         }
     }
 
@@ -57,11 +54,14 @@ internal class EpisodeControllerImpl(
         longLivingScope.launch {
             val currentlyPlayingEpisode = episodesRepository.getCurrentEpisode().firstOrNull()
             if (currentlyPlayingEpisode?.id == episodeId) {
-                // Play next only if the currently playing episode is marked as played, otherwise we'd be changing
-                // the media even when the user didn't intend to do that
-                playNextFromQueueOnMediaEnded(currentlyPlayingEpisode)
+                if (playerController.hasNext()) {
+                    playerController.playNext()
+                } else {
+                    playerController.pause()
+                }
             }
             episodesRepository.markPlayed(episodeId)
+            playerController.updateQueue()
         }
     }
 
@@ -81,61 +81,6 @@ internal class EpisodeControllerImpl(
         longLivingScope.launch {
             episodesRepository.updateFavorite(id = episodeId, isFavorite = false)
         }
-    }
-
-    // Almost replicated in PodcastMediaSessionService
-    private suspend fun playNextFromQueueOnMediaEnded(currentlyPlayingEpisode: Episode?) {
-        LogHelper.d(TAG, "Finding next media to play")
-
-        if (currentlyPlayingEpisode == null) {
-            LogHelper.d(TAG, "Currently playing episode is null")
-            return
-        }
-
-        fun onDone() {
-            playerController.pause()
-        }
-
-        val playingState = settings.getPlayingStateFlow().first()
-        if (playingState == PlayingState.NOT_PLAYING) {
-            LogHelper.d(TAG, "Currently not playing")
-            onDone()
-            return
-        }
-
-        val autoPlayNextInQueue = settings.autoPlayNextInQueue().first()
-        if (!autoPlayNextInQueue) {
-            LogHelper.d(TAG, "Auto play next in queue is false")
-            onDone()
-            return
-        }
-
-        val sleepTimer = settings.getSleepTimerFlow().first()
-        if (sleepTimer is SleepTimer.EndOfEpisode) {
-            LogHelper.d(TAG, "Sleep timer is set to end of episode")
-            settings.setSleepTimer(SleepTimer.None)
-            onDone()
-            return
-        }
-
-        val queue = episodesRepository.getQueue()
-        val currentEpisodeIndex = queue.indexOfFirst { it.id == currentlyPlayingEpisode.id }
-        if (currentEpisodeIndex == -1) {
-            LogHelper.v(TAG, "current episode not found in queue")
-            onDone()
-            return
-        }
-
-        val nextEpisode = queue.getOrNull(currentEpisodeIndex + 1)
-        if (nextEpisode == null) {
-            LogHelper.v(TAG, "next episode is null")
-            onDone()
-            return
-        }
-
-        LogHelper.d(TAG, "Found next media: ${nextEpisode.title}")
-        onDone()
-        playEpisode(nextEpisode)
     }
 
     private suspend fun playEpisode(episode: Episode) {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/utils/QueueRearrangementHelper.kt
@@ -1,5 +1,6 @@
 package com.ramitsuri.podcasts.utils
 
+import com.ramitsuri.podcasts.player.PlayerController
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -12,6 +13,7 @@ import kotlinx.coroutines.launch
 class QueueRearrangementHelper(
     scope: CoroutineScope,
     repo: EpisodesRepository,
+    playerController: PlayerController,
 ) {
     private val _queuePositions = MutableStateFlow<Map<String, Int>>(mapOf())
     val queuePositions = _queuePositions.asStateFlow()
@@ -37,6 +39,7 @@ class QueueRearrangementHelper(
         scope.launch {
             queueRearrangementChannel.consumeEach { positions ->
                 repo.updateQueuePositions(positions.id1, positions.position1, positions.id2, positions.position2)
+                playerController.updateQueue()
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -2,6 +2,7 @@ package com.ramitsuri.podcasts.viewmodel
 
 import com.ramitsuri.podcasts.model.PlayingState
 import com.ramitsuri.podcasts.model.ui.QueueViewState
+import com.ramitsuri.podcasts.player.PlayerController
 import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.settings.Settings
 import com.ramitsuri.podcasts.utils.EpisodeController
@@ -15,8 +16,10 @@ class QueueViewModel internal constructor(
     episodeController: EpisodeController,
     settings: Settings,
     episodesRepository: EpisodesRepository,
+    playerController: PlayerController,
 ) : ViewModel(), EpisodeController by episodeController {
-    private val queueRearrangementHelper = QueueRearrangementHelper(viewModelScope, episodesRepository)
+    private val queueRearrangementHelper =
+        QueueRearrangementHelper(viewModelScope, episodesRepository, playerController)
 
     val state =
         combine(


### PR DESCRIPTION
Auto play next in queue while keeping app state as the single source
of truth, setting next episode on the player when current episode
ends doesn't work on newer versions of Android because media can't
be played from background as it starts a foreground service.a

The fix was to use media3 player's playlist to keep a copy of the
queue in there as well so that player can automatically go to the next
episode even from background.

There are several ways a queue that needs to be set on the player can
be changed
- Sleep timer end of episode
- Auto play on/off
- App queue is updated

For now, all of these actions are manually invoking `player.updateQueue`
because listening to changes in all of those values was causing issues
with playback, adding a lot of stutters. Probably need to debounce
requests to update player queue when that happens. Will explore that
option later and want to get this out right now so that the strategy
can be tested more.
