### PR TITLE
Fix items not refreshing on data change

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/history/EpisodeHistoryScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/history/EpisodeHistoryScreen.kt
@@ -80,7 +80,7 @@ fun EpisodeHistoryScreen(
                 stickyHeader {
                     HeaderItem(text = dateFormatted(date))
                 }
-                items(episodes) {
+                items(items = episodes, key = { it.id }) {
                     ColoredHorizontalDivider()
                     EpisodeItem(
                         episode = it,

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/home/HomeScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/home/HomeScreen.kt
@@ -130,7 +130,7 @@ fun HomeScreen(
                     )
                 }
             }
-            items(state.episodes) {
+            items(key = { it.id }, items = state.episodes) {
                 ColoredHorizontalDivider()
                 EpisodeItem(
                     episode = it,
@@ -201,7 +201,7 @@ private fun Subscriptions(
             item {
                 Spacer(modifier = Modifier.width(8.dp))
             }
-            items(podcasts) {
+            items(items = podcasts, key = { it.id }) {
                 SubscribedPodcastItem(
                     title = it.title,
                     artwork = it.artwork,

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
@@ -244,7 +244,7 @@ private fun PodcastDetails(
                 toggleAutoAddToQueueClicked = toggleAutoAddToQueueClicked,
             )
         }
-        items(key = { it.episode.id } , items = podcastWithEpisodes.episodes) {
+        items(key = { it.episode.id }, items = podcastWithEpisodes.episodes) {
             val episode = it.episode
             ColoredHorizontalDivider()
             EpisodeItem(

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
@@ -244,7 +244,7 @@ private fun PodcastDetails(
                 toggleAutoAddToQueueClicked = toggleAutoAddToQueueClicked,
             )
         }
-        items(podcastWithEpisodes.episodes) {
+        items(key = { it.episode.id } , items = podcastWithEpisodes.episodes) {
             val episode = it.episode
             ColoredHorizontalDivider()
             EpisodeItem(

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/search/SearchScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/search/SearchScreen.kt
@@ -262,7 +262,7 @@ private fun SearchResults(
             item {
                 Spacer(modifier = Modifier.height(16.dp))
             }
-            items(podcasts) {
+            items(items = podcasts, key = { it.id }) {
                 ColoredHorizontalDivider()
                 PodcastInfoItem(it, onClick = onPodcastClicked)
             }

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/subscriptions/SubscriptionsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/subscriptions/SubscriptionsScreen.kt
@@ -68,7 +68,7 @@ fun SubscriptionsScreen(
                     .padding(horizontal = 16.dp),
         ) {
             fullWidthSpacer()
-            items(state.subscribedPodcasts) { podcast ->
+            items(items = state.subscribedPodcasts, key = { it.id }) { podcast ->
                 SubscribedPodcastItem(podcast = podcast, onClicked = { onPodcastClicked(it.id) })
             }
             fullWidthSpacer()


### PR DESCRIPTION
Was easily reproducible on home screen. Marking an episode as played
for ex would remove that episode from the list, but the new episode
that would take its place in the list, would still have the old
episode's duration.

Added key to all LazyLists
