### PR TITLE
Fix history crash

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/history/EpisodeHistoryScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/history/EpisodeHistoryScreen.kt
@@ -80,7 +80,7 @@ fun EpisodeHistoryScreen(
                 stickyHeader {
                     HeaderItem(text = dateFormatted(date))
                 }
-                items(items = episodes, key = { it.id }) {
+                items(items = episodes, key = { date.toString() + it.id }) {
                     ColoredHorizontalDivider()
                     EpisodeItem(
                         episode = it,


### PR DESCRIPTION
Since the history list can have multiple items for the same episode,
couldn't use episode id as the key for lazy list and that was causing
a crash. Added date as well to the key which should make each entry
unique
