### PR TITLE
Fix history screen crash

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/history/EpisodeHistoryScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/history/EpisodeHistoryScreen.kt
@@ -80,28 +80,29 @@ fun EpisodeHistoryScreen(
                 stickyHeader {
                     HeaderItem(text = dateFormatted(date))
                 }
-                items(items = episodes, key = { date.toString() + it.id }) {
+                items(items = episodes, key = { date.toString() + it.episode.id + it.sessionId }) {
+                    val episode = it.episode
                     ColoredHorizontalDivider()
                     EpisodeItem(
-                        episode = it,
+                        episode = episode,
                         playingState =
-                            if (state.currentlyPlayingEpisodeId == it.id) {
+                            if (state.currentlyPlayingEpisodeId == episode.id) {
                                 state.currentlyPlayingEpisodeState
                             } else {
                                 PlayingState.NOT_PLAYING
                             },
-                        onClicked = { onEpisodeClicked(it.id) },
-                        onPlayClicked = { onEpisodePlayClicked(it) },
+                        onClicked = { onEpisodeClicked(episode.id) },
+                        onPlayClicked = { onEpisodePlayClicked(episode) },
                         onPauseClicked = onEpisodePauseClicked,
-                        onAddToQueueClicked = { onEpisodeAddToQueueClicked(it) },
-                        onRemoveFromQueueClicked = { onEpisodeRemoveFromQueueClicked(it) },
-                        onDownloadClicked = { onEpisodeDownloadClicked(it) },
-                        onRemoveDownloadClicked = { onEpisodeRemoveDownloadClicked(it) },
-                        onCancelDownloadClicked = { onEpisodeCancelDownloadClicked(it) },
-                        onPlayedClicked = { onEpisodePlayedClicked(it.id) },
-                        onNotPlayedClicked = { onEpisodeNotPlayedClicked(it.id) },
-                        onFavoriteClicked = { onEpisodeFavoriteClicked(it.id) },
-                        onNotFavoriteClicked = { onEpisodeNotFavoriteClicked(it.id) },
+                        onAddToQueueClicked = { onEpisodeAddToQueueClicked(episode) },
+                        onRemoveFromQueueClicked = { onEpisodeRemoveFromQueueClicked(episode) },
+                        onDownloadClicked = { onEpisodeDownloadClicked(episode) },
+                        onRemoveDownloadClicked = { onEpisodeRemoveDownloadClicked(episode) },
+                        onCancelDownloadClicked = { onEpisodeCancelDownloadClicked(episode) },
+                        onPlayedClicked = { onEpisodePlayedClicked(episode.id) },
+                        onNotPlayedClicked = { onEpisodeNotPlayedClicked(episode.id) },
+                        onFavoriteClicked = { onEpisodeFavoriteClicked(episode.id) },
+                        onNotFavoriteClicked = { onEpisodeNotFavoriteClicked(episode.id) },
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/EpisodeHistory.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/EpisodeHistory.kt
@@ -4,5 +4,6 @@ import kotlinx.datetime.Instant
 
 data class EpisodeHistory(
     val episode: Episode,
+    val sessionId: String,
     val time: Instant,
 )

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/ui/EpisodeHistoryViewState.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/ui/EpisodeHistoryViewState.kt
@@ -1,11 +1,11 @@
 package com.ramitsuri.podcasts.model.ui
 
-import com.ramitsuri.podcasts.model.Episode
+import com.ramitsuri.podcasts.model.EpisodeHistory
 import com.ramitsuri.podcasts.model.PlayingState
 import kotlinx.datetime.LocalDate
 
 data class EpisodeHistoryViewState(
-    val episodesByDate: Map<LocalDate, List<Episode>> = mapOf(),
+    val episodesByDate: Map<LocalDate, List<EpisodeHistory>> = mapOf(),
     val currentlyPlayingEpisodeId: String? = null,
     val currentlyPlayingEpisodeState: PlayingState = PlayingState.NOT_PLAYING,
 )

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/SessionHistoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/SessionHistoryRepository.kt
@@ -152,7 +152,7 @@ class SessionHistoryRepository internal constructor(
                 sessionActionEntities.mapNotNull { sessionActionEntity ->
                     episodesRepository.getEpisode(sessionActionEntity.episodeId)
                         ?.let { episode ->
-                            EpisodeHistory(episode, sessionActionEntity.time)
+                            EpisodeHistory(episode, sessionActionEntity.sessionId, sessionActionEntity.time)
                         }
                 }.mergeConsecutiveDuplicateEpisodes(timeZone)
             }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
@@ -1,6 +1,5 @@
 package com.ramitsuri.podcasts.viewmodel
 
-import com.ramitsuri.podcasts.model.Episode
 import com.ramitsuri.podcasts.model.EpisodeHistory
 import com.ramitsuri.podcasts.model.PlayingState
 import com.ramitsuri.podcasts.model.ui.EpisodeHistoryViewState

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
@@ -41,13 +41,12 @@ class EpisodeHistoryViewModel internal constructor(
             initialValue = EpisodeHistoryViewState(),
         )
 
-    private fun List<EpisodeHistory>.groupedByDate(): Map<LocalDate, List<Episode>> {
+    private fun List<EpisodeHistory>.groupedByDate(): Map<LocalDate, List<EpisodeHistory>> {
         return groupBy { episodeHistory ->
             episodeHistory.time.toLocalDateTime(timeZone).date
         }.mapValues { (_, episodeHistories) ->
             episodeHistories
                 .sortedByDescending { it.time }
-                .map { it.episode }
         }
     }
 }


### PR DESCRIPTION
Noticed that the key was somehow still not unique on the history list
screen which not sure how that would happen since one episode could
appear only once in a single day and the key is being generated using
the date of playback for the episode.

Anyway, added session id to the key as well to see if this fixes it.
