### PR TITLE
Disable remote logging by default

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/MainApplication.kt
@@ -126,7 +126,7 @@ class MainApplication : Application(), ImageLoaderFactory, KoinComponent {
                 single<Logger> {
                     AndroidLogger(
                         isDebug = BuildConfig.DEBUG,
-                        enableRemote = !BuildConfig.DEBUG,
+                        enableRemote = false,
                         deviceModel = Build.MODEL,
                     )
                 }

--- a/shared/src/androidMain/kotlin/com/ramitsuri/podcasts/utils/AndroidLogger.kt
+++ b/shared/src/androidMain/kotlin/com/ramitsuri/podcasts/utils/AndroidLogger.kt
@@ -71,7 +71,7 @@ class AndroidLogger(
     }
 
     private fun getDb(time: Instant): DatabaseReference {
-        return Firebase.database.getReference("logs/$deviceId/${formatLogParent(time)}")
+        return Firebase.database.getReference("logs-v2/$deviceId/${formatLogParent(time)}")
     }
 
     private fun formatLogTime(time: Instant): String {


### PR DESCRIPTION
Remote logging was enabled by default. Disabling it and changed
the root document of realtime db to `logs-v2` to stop existing
installs from sending anymore logs.
