### PR TITLE
Fix year end review tracking bug

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/SessionHistoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/SessionHistoryRepository.kt
@@ -221,7 +221,9 @@ class SessionHistoryRepository internal constructor(
                         val startBeforeCurrentDayEndInCurrentDay =
                             sessions
                                 .filter { session ->
-                                    session.startTime < dayOfYear.startTime && session.endTime <= dayOfYear.endTime
+                                    session.startTime < dayOfYear.startTime &&
+                                        session.endTime > dayOfYear.startTime &&
+                                        session.endTime <= dayOfYear.endTime
                                 }
                                 .sumOf { session ->
                                     session.endTime.minus(dayOfYear.startTime)
@@ -229,7 +231,9 @@ class SessionHistoryRepository internal constructor(
                         val startCurrentDayEndAfterCurrentDay =
                             sessions
                                 .filter { session ->
-                                    session.startTime >= dayOfYear.startTime && session.endTime > dayOfYear.endTime
+                                    session.startTime >= dayOfYear.startTime &&
+                                        session.startTime < dayOfYear.endTime &&
+                                        session.endTime > dayOfYear.endTime
                                 }
                                 .sumOf { session ->
                                     dayOfYear.endTime.minus(session.startTime)
@@ -239,7 +243,7 @@ class SessionHistoryRepository internal constructor(
                                 .filter { session ->
                                     session.startTime < dayOfYear.startTime && session.endTime > dayOfYear.endTime
                                 }
-                                .sumOf { session ->
+                                .sumOf {
                                     dayOfYear.endTime.minus(dayOfYear.startTime)
                                 }
                         val startCurrentDayEndCurrentDay =


### PR DESCRIPTION
Was not tracking which session fell into what day correctly for sessions that span multiple days