### PR TITLE
Fix back button not closing player

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
@@ -178,9 +178,6 @@ fun NavGraph(
             targetValue = if (isExpanded) 16.dp else 0.dp,
             label = "rounded_corner_animation",
         )
-        BackHandler(isExpanded) {
-            expandOrCollapsePlayer(false)
-        }
         BottomSheetScaffold(
             scaffoldState = scaffoldSheetState,
             sheetPeekHeight = bottomPadding,
@@ -808,7 +805,9 @@ fun NavGraph(
                         )
                     }
                 }
-
+                BackHandler(isExpanded) {
+                    expandOrCollapsePlayer(false)
+                }
                 AnimatedVisibility(
                     visible = isExpanded,
                     enter = fadeIn(),


### PR DESCRIPTION
When player is open on a different screen than home, pressing back
was navigating out of that screen rather than closing player first.

Looks like the order of where back handler is planted matters.
Moving it to top of all screens (since the parent of all screens is
a Box) fixes it.
