### PR TITLE
Attempt to fix missing player and bottom nav

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
@@ -112,8 +112,8 @@ fun NavGraph(
             }
         }
     }
-    var canShowBottomNav by remember { mutableStateOf(!isExpanded) }
-    var canShowPlayer by remember { mutableStateOf(!isExpanded) }
+    var canShowBottomNav by remember(scaffoldSheetState.bottomSheetState) { mutableStateOf(!isExpanded) }
+    var canShowPlayer by remember(scaffoldSheetState.bottomSheetState) { mutableStateOf(!isExpanded) }
 
     val coroutineScope = rememberCoroutineScope()
 


### PR DESCRIPTION
Noticed that some times the mini player and the bottom nav bar would
go missing. One way to bring them back would be to go into backup and
restore screen and nav back from there because entering/exiting that
screen hides/shows them.
Not entirely sure what's going on but probably the bottom sheet state
is not triggering something somewhere.
Making the bottom sheet state the key for remembering vars for
showing/hiding the bottom nav bar and mini player
