### PR TITLE
Fix queue rearrangement getting broken some times

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/settings/Key.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/settings/Key.kt
@@ -13,6 +13,7 @@ internal enum class Key(val value: String) {
     REMOVE_UNFINISHED_EPISODES_AFTER("remove_unfinished_episodes_after"),
     REMOTE_LOGGING_ENABLED("remote_logging_enabled"),
     SHOULD_DOWNLOAD_ON_WIFI_ONLY("should_download_on_wifi_only"),
+    IS_DUPLICATE_QUEUE_POSITIONS_FIXED("is_duplicate_queue_positions_fixed"),
     ;
 
     companion object {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/settings/Settings.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/settings/Settings.kt
@@ -7,6 +7,7 @@ import com.ramitsuri.podcasts.utils.Constants
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.datetime.Clock
@@ -160,5 +161,13 @@ class Settings internal constructor(private val keyValueStore: KeyValueStore) {
 
     suspend fun setShouldDownloadOnWifiOnly(shouldDownloadOnWifiOnly: Boolean) {
         keyValueStore.putBoolean(Key.SHOULD_DOWNLOAD_ON_WIFI_ONLY, shouldDownloadOnWifiOnly)
+    }
+
+    suspend fun isDuplicateQueuePositionsIssueFixed(): Boolean {
+        return keyValueStore.getBooleanFlow(Key.IS_DUPLICATE_QUEUE_POSITIONS_FIXED, false).first()
+    }
+
+    suspend fun setIsDuplicateQueuePositionsIssueFixed(fixed: Boolean) {
+        keyValueStore.putBoolean(Key.IS_DUPLICATE_QUEUE_POSITIONS_FIXED, fixed)
     }
 }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/QueueViewModel.kt
@@ -21,6 +21,17 @@ class QueueViewModel internal constructor(
     private val queueRearrangementHelper =
         QueueRearrangementHelper(viewModelScope, episodesRepository, playerController)
 
+    init {
+        viewModelScope.launch {
+            if (!settings.isDuplicateQueuePositionsIssueFixed()) {
+                episodesRepository.getQueue().forEachIndexed { index, episode ->
+                    episodesRepository.updateQueuePosition(episode.id, index)
+                }
+                settings.setIsDuplicateQueuePositionsIssueFixed(true)
+            }
+        }
+    }
+
     val state =
         combine(
             queueRearrangementHelper.queuePositions,


### PR DESCRIPTION
This has been an ongoing issue where the queue rearrangement doesn't
work at times. Trying to drag an item just glitches and it's
impossible to place the episode item in the desired queue position.

Finally was able to figure out what was going on. It was possible
for multiple episodes to get the same queue position. That's because
on adding an episode to queue, the queue position is derived from
the max existing queue position and adding 1 to it. There's a setting
to automatically add new episodes to queue and that happens when
refreshing podcasts. However, all the refreshes happen in parallel
and so if multiple podcasts have auto add to queue on, the new
episodes would get added to the queue at the same time, getting
the same queue position. Which causes the issue

Making it so that add to queue requests are sequential now
