### PR TITLE
Fix download state out of sync

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/MainApplication.kt
@@ -123,6 +123,9 @@ class MainApplication : Application(), ImageLoaderFactory, KoinComponent {
                 single<EpisodeDownloader> {
                     EpisodeDownloaderImpl(
                         appContext = get<Application>(),
+                        downloadManager = get<DownloadManager>(),
+                        episodesRepository = get<EpisodesRepository>(),
+                        coroutineScope = get<CoroutineScope>(),
                     )
                 }
 

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/DownloadManagerListener.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/DownloadManagerListener.kt
@@ -21,13 +21,10 @@ class DownloadManagerListener(
         downloadManager: DownloadManager,
         download: Download,
     ) {
+        LogHelper.d(TAG, "onDownloadRemoved: $download")
         longLivingScope.launch {
             val episodeId = download.request.id
-            episodesRepository.updateDownloadBlocked(episodeId, true)
-            episodesRepository.updateDownloadStatus(episodeId, DownloadStatus.NOT_DOWNLOADED)
-            episodesRepository.updateDownloadProgress(episodeId, 0.0)
-            episodesRepository.updateDownloadedAt(episodeId, null)
-            episodesRepository.updateNeedsDownload(episodeId, false)
+            episodesRepository.updateDownloadRemoved(episodeId)
         }
     }
 
@@ -36,6 +33,7 @@ class DownloadManagerListener(
         download: Download,
         finalException: Exception?,
     ) {
+        LogHelper.d(TAG, "onDownloadChanged: $download")
         val (state, needsDownload) =
             when (download.state) {
                 Download.STATE_QUEUED -> Pair(DownloadStatus.QUEUED, null)

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/EpisodeDownloaderImpl.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/media/EpisodeDownloaderImpl.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.media3.exoplayer.scheduler.Requirements
@@ -11,11 +12,32 @@ import coil.imageLoader
 import com.ramitsuri.podcasts.android.utils.Constants
 import com.ramitsuri.podcasts.download.EpisodeDownloader
 import com.ramitsuri.podcasts.model.Episode
+import com.ramitsuri.podcasts.repositories.EpisodesRepository
 import com.ramitsuri.podcasts.utils.LogHelper
 import com.ramitsuri.podcasts.utils.imageRequest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 @OptIn(UnstableApi::class)
-class EpisodeDownloaderImpl(private val appContext: Context) : EpisodeDownloader {
+class EpisodeDownloaderImpl(
+    private val appContext: Context,
+    private val downloadManager: DownloadManager,
+    private val episodesRepository: EpisodesRepository,
+    coroutineScope: CoroutineScope,
+) : EpisodeDownloader {
+    init {
+        coroutineScope.launch {
+            episodesRepository.getDownloadedFlow().collect {
+                it.forEach { downloadedEpisode ->
+                    // App thinks episode is downloaded but download manager doesn't
+                    if (downloadManager.downloadIndex.getDownload(downloadedEpisode.id) == null) {
+                        episodesRepository.updateDownloadRemoved(downloadedEpisode.id)
+                    }
+                }
+            }
+        }
+    }
+
     override fun add(episode: Episode) {
         LogHelper.d(TAG, "Adding ${episode.title}")
         // Episode download

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/BackupData.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/model/BackupData.kt
@@ -284,14 +284,18 @@ fun EpisodeAdditionalInfoEntity.fromEntity() =
     BackupData.EpisodeAdditionalInfoData(
         id = this.id,
         playProgress = this.playProgress,
-        downloadStatus = this.downloadStatus,
-        downloadProgress = this.downloadProgress,
+        // When backing up, the actual download files are not backed up, so download status is NOT_DOWNLOADED
+        downloadStatus = DownloadStatus.NOT_DOWNLOADED,
+        downloadProgress = 0.0,
         downloadBlocked = this.downloadBlocked,
-        downloadedAt = this.downloadedAt,
+        downloadedAt = null,
         queuePosition = this.queuePosition,
         completedAt = this.completedAt,
         isFavorite = this.isFavorite,
-        needsDownload = this.needsDownload,
+        needsDownload =
+            this.needsDownload ||
+                this.downloadStatus == DownloadStatus.DOWNLOADED ||
+                this.downloadStatus == DownloadStatus.DOWNLOADING,
     )
 
 fun SessionActionEntity.fromEntity() =

--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/repositories/EpisodesRepository.kt
@@ -233,7 +233,7 @@ class EpisodesRepository internal constructor(
         episodesDao.updateDownloadProgress(id, progress)
     }
 
-    suspend fun updateDownloadBlocked(
+    private suspend fun updateDownloadBlocked(
         id: String,
         blocked: Boolean,
     ) {
@@ -245,6 +245,14 @@ class EpisodesRepository internal constructor(
         downloadedAt: Instant? = Clock.System.now(),
     ) {
         episodesDao.updateDownloadedAt(id, downloadedAt)
+    }
+
+    suspend fun updateDownloadRemoved(id: String) {
+        updateDownloadBlocked(id, true)
+        updateDownloadStatus(id, DownloadStatus.NOT_DOWNLOADED)
+        updateDownloadProgress(id, 0.0)
+        updateDownloadedAt(id, null)
+        updateNeedsDownload(id, false)
     }
 
     suspend fun updateQueuePositions(


### PR DESCRIPTION
Noticed that some times app would think that episode was downloaded
but it wasn't and you couldn't send the remove download request
because it wasn't downloaded according to media3 download manager.

Listening for downloaded episodes now and updating app downloaded
state based on state in media3 download manager
