### PR TITLE
Fix HomeScreen not loaded if started via deeplink

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
@@ -971,8 +971,11 @@ private fun NavHostController.navigateToMainDestination(to: BottomNavItem): Bool
     }
     navigate(to.route.value) {
         // So that pressing back from any main bottom tab item leads user to home tab first
-        popUpTo(BottomNavItem.HOME.route.value)
+        popUpTo(BottomNavItem.HOME.route.value) {
+            saveState = true
+        }
         launchSingleTop = true
+        restoreState = true
     }
     return true
 }

--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
@@ -972,10 +972,12 @@ private fun NavHostController.navigateToMainDestination(to: BottomNavItem): Bool
     navigate(to.route.value) {
         // So that pressing back from any main bottom tab item leads user to home tab first
         popUpTo(BottomNavItem.HOME.route.value) {
-            saveState = true
+            // Popup inclusive of home as well if navigating to home. This fixes a bug where if the app is launched via
+            // episode details deeplink and then home tab button is tapped, the home screen state is not loaded for some
+            // reason.
+            inclusive = to == BottomNavItem.HOME
         }
         launchSingleTop = true
-        restoreState = true
     }
     return true
 }


### PR DESCRIPTION
Fixed a weird issue where if app is launched from deeplink for
episode details and then home tab button is tapped, home screen
view state is not loaded. Gemini suggested saving and restoring
state when navigating but that didn't work.

That gave me the idea to maybe pop the home screen first if we're
navigating to home screen top level destination which fixes the
issue
