### PR TITLE
Fix podcast details menu button not always visible

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/ui/podcast/PodcastDetailsScreen.kt
@@ -582,28 +582,26 @@ private fun PodcastHeader(
                 toggleAutoDownloadClicked = toggleAutoDownloadClicked,
                 toggleAutoAddToQueueClicked = toggleAutoAddToQueueClicked,
             )
-            if (count > 0) {
-                EpisodesMenu(
-                    showMenu = showMenu,
-                    onToggleMenu = { showMenu = !showMenu },
-                    showSortOrder = selectedCount == 0,
-                    sortOrder = sortOrder,
-                    showSelectAll = selectedCount > 0 && selectedCount != count,
-                    showUnselectAll = selectedCount != 0,
-                    showMarkAsPlayed = selectedCount != 0,
-                    showMarkAsNotPlayed = selectedCount != 0,
-                    showCompletedEpisodes = showCompletedEpisodes,
-                    showCompletedEpisodesMenuItem = selectedCount == 0,
-                    showSearchEpisodes = selectedCount == 0,
-                    onSortOrderClicked = onSortOrderClicked,
-                    onSelectAllClicked = onSelectAllClicked,
-                    onUnselectAllClicked = onUnselectAllClicked,
-                    onMarkSelectedAsPlayed = onMarkSelectedAsPlayed,
-                    onMarkSelectedAsNotPlayed = onMarkSelectedAsNotPlayed,
-                    toggleShowCompletedEpisodesClicked = toggleShowCompletedEpisodesClicked,
-                    onSearchEpisodes = { showSearch = true },
-                )
-            }
+            EpisodesMenu(
+                showMenu = showMenu,
+                onToggleMenu = { showMenu = !showMenu },
+                showSortOrder = selectedCount == 0,
+                sortOrder = sortOrder,
+                showSelectAll = selectedCount > 0 && selectedCount != count,
+                showUnselectAll = selectedCount != 0,
+                showMarkAsPlayed = selectedCount != 0,
+                showMarkAsNotPlayed = selectedCount != 0,
+                showCompletedEpisodes = showCompletedEpisodes,
+                showCompletedEpisodesMenuItem = selectedCount == 0,
+                showSearchEpisodes = selectedCount == 0,
+                onSortOrderClicked = onSortOrderClicked,
+                onSelectAllClicked = onSelectAllClicked,
+                onUnselectAllClicked = onUnselectAllClicked,
+                onMarkSelectedAsPlayed = onMarkSelectedAsPlayed,
+                onMarkSelectedAsNotPlayed = onMarkSelectedAsNotPlayed,
+                toggleShowCompletedEpisodesClicked = toggleShowCompletedEpisodesClicked,
+                onSearchEpisodes = { showSearch = true },
+            )
         }
         Spacer(modifier = Modifier.height(16.dp))
         Box(


### PR DESCRIPTION
When all episodes are marked as completed in a podcast and completed
episodes are hidden, the menu button to show completed episodes would
also be hidden, resulting in no way of showing completed episodes
again.

The menu button should always be visible now.
