### PR TITLE
Keep episode, podcast details in backstack

### DIFF
--- a/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
+++ b/androidApp/src/main/java/com/ramitsuri/podcasts/android/navigation/NavGraph.kt
@@ -440,7 +440,7 @@ fun NavGraph(
                                 navOptions {
                                     popUpTo(
                                         Route.EPISODE_DETAILS.routeWithArgName(),
-                                        popUpToBuilder = { inclusive = true },
+                                        popUpToBuilder = { inclusive = false },
                                     )
                                 },
                             )
@@ -493,7 +493,7 @@ fun NavGraph(
                                 navOptions {
                                     popUpTo(
                                         Route.PODCAST_DETAILS.routeWithArgName(),
-                                        popUpToBuilder = { inclusive = true },
+                                        popUpToBuilder = { inclusive = false },
                                     )
                                 },
                             )


### PR DESCRIPTION
Keeping them in backstack even if you can keep navigating to
episode -> podcast -> episode -> podcast because it's a worse
experience when backing out otherwise
