### PR TITLE
Fix too many sql vars crash

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/interfaces/SessionActionDaoImpl.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/database/dao/interfaces/SessionActionDaoImpl.kt
@@ -56,7 +56,10 @@ internal class SessionActionDaoImpl(
     ): List<EpisodeAndPodcastId> {
         return withContext(ioDispatcher) {
             sessionHistoryQueries
-                .getEpisodes(episodeIds = episodeIds, podcastIds = podcastIds)
+                .getEpisodes(
+                    episodeIds = episodeIds.take(SQLITE_MAX_VARIABLE_NUMBER),
+                    podcastIds = podcastIds.take(SQLITE_MAX_VARIABLE_NUMBER),
+                )
                 .executeAsList()
                 .map {
                     EpisodeAndPodcastId(
@@ -81,5 +84,10 @@ internal class SessionActionDaoImpl(
             .asFlow()
             .mapToOne(ioDispatcher)
             .map { it > 0 }
+    }
+
+    companion object {
+        // Limit max vars otherwise causes exception - too many SQL variables (Sqlite code 1 SQLITE_ERROR)
+        private const val SQLITE_MAX_VARIABLE_NUMBER = 999
     }
 }


### PR DESCRIPTION
Was seeing the following crash so limiting the number of vars
supplied to sql query to 999 based on

> To prevent excessive memory allocations, the maximum value
of a host parameter number is SQLITE_MAX_VARIABLE_NUMBER, which
defaults to 999 for SQLite versions prior to 3.32.0 (2020-05-22)
or 32766 for SQLite versions after 3.32.0.

```
Fatal Exception: android.database.sqlite.SQLiteException
too many SQL variables (Sqlite code 1 SQLITE_ERROR): , while compiling: SELECT episodeId, podcastId FROM SessionActionEntity WHERE episodeId IN...
```
