### PR TITLE
Fix episode history screen crash

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/EpisodeHistoryViewModel.kt
@@ -51,12 +51,16 @@ class EpisodeHistoryViewModel internal constructor(
         }.mapValues { (_, sessionEpisodes) ->
             sessionEpisodes
                 .sortedByDescending { it.time }
-                .map { sessionEpisode ->
-                    EpisodeHistory(
-                        episodes.first { it.id == sessionEpisode.episodeId },
-                        sessionEpisode.sessionId,
-                        sessionEpisode.time,
-                    )
+                .mapNotNull { sessionEpisode ->
+                    episodes
+                        .firstOrNull { it.id == sessionEpisode.episodeId }
+                        ?.let { episode ->
+                            EpisodeHistory(
+                                episode,
+                                sessionEpisode.sessionId,
+                                sessionEpisode.time,
+                            )
+                        }
                 }
         }
     }


### PR DESCRIPTION
Saw another crash. Not sure how we would have an episode in
session history but not in episodes table as well. But just
doing a quick fix for now.

```
Fatal Exception: java.util.NoSuchElementException: Collection contains no element matching the predicate.
       at com.ramitsuri.podcasts.viewmodel.EpisodeHistoryViewModel.groupedByDate(EpisodeHistoryViewModel.kt:88)
       at com.ramitsuri.podcasts.viewmodel.EpisodeHistoryViewModel.access$groupedByDate(EpisodeHistoryViewModel.kt)
       at com.ramitsuri.podcasts.viewmodel.EpisodeHistoryViewModel$state$1.invokeSuspend(EpisodeHistoryViewModel.kt:41)
```

https://console.firebase.google.com/project/podcasts-5f0ae/crashlytics/app/android:com.ramitsuri.podcasts.android/issues/b83ad15ca5df9c3c8ab8c010bff68be1?time=7d&types=crash&sessionEventKey=69494E0B01BC00014BFC18618BD5BB1F_2165126473720960620
