### PR TITLE
Fix potential downloads screen crash

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/DownloadsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/podcasts/viewmodel/DownloadsViewModel.kt
@@ -28,7 +28,7 @@ class DownloadsViewModel internal constructor(
                     null
                 }
             DownloadsViewState(
-                episodes = downloadedEpisodes + downloadingEpisodes,
+                episodes = (downloadedEpisodes + downloadingEpisodes).distinctBy { it.id },
                 currentlyPlayingEpisodeId = currentlyPlaying?.id,
                 currentlyPlayingEpisodeState = playingState,
             )


### PR DESCRIPTION
There could be a moment where an episode is downloaded as well as
downloading as because of a race condition causing a crash in the
Lazy List. Making them distinct
