### PR TITLE
Allow clear text traffic

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:enableOnBackInvokedCallback="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Podcasts.Splash">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
Some BBC podcasts are hosted on http urls which by default fails
to load on ExoPlayer. So allowing clear text traffic.
This is what PocketCasts does as well
https://github.com/Automattic/pocket-casts-android/blob/aa0980e6c3769cdf0839f0ab26b52ab22f3a2b5b/app/src/main/AndroidManifest.xml#L42
